### PR TITLE
PASELC-511 fix redirect to wait after iban delete

### DIFF
--- a/src/pages/iban/detail/IbanDetailPage.tsx
+++ b/src/pages/iban/detail/IbanDetailPage.tsx
@@ -71,10 +71,11 @@ const IbanDetailPage = () => {
     }
   }, [selectedParty, ibanId]);
 
-  const deleteIbans = async () => {
+  const deleteIbanHandler = async () => {
     setLoadingDelete(true);
     try {
       await deleteIban(selectedParty?.fiscalCode ?? '', ibanId);
+      history.push(ROUTES.IBAN);
     } catch (reason) {
       handleErrors([
         {
@@ -130,7 +131,7 @@ const IbanDetailPage = () => {
             </Typography>
           </Grid>
           <Grid item xs={6}>
-            <IbanDetailButtons active={iban.active} iban={ibanId} deleteIbans={deleteIbans} />
+            <IbanDetailButtons active={iban.active} iban={ibanId} deleteIban={deleteIbanHandler} />
           </Grid>
         </Grid>
 

--- a/src/pages/iban/detail/__tests__/IbanDetailButtons.test.tsx
+++ b/src/pages/iban/detail/__tests__/IbanDetailButtons.test.tsx
@@ -27,7 +27,7 @@ describe('IbanDetailButtons', (injectedHistory?: ReturnType<typeof createMemoryH
       <Provider store={store}>
         <Router history={history}>
           <ThemeProvider theme={theme}>
-            <IbanDetailButtons active={active} iban={iban} deleteIbans={jest.fn()} />
+            <IbanDetailButtons active={active} iban={iban} deleteIban={jest.fn()} />
           </ThemeProvider>
         </Router>
       </Provider>
@@ -46,7 +46,7 @@ describe('IbanDetailButtons', (injectedHistory?: ReturnType<typeof createMemoryH
       <Provider store={store}>
         <Router history={history}>
           <ThemeProvider theme={theme}>
-            <IbanDetailButtons active={active} iban={iban} deleteIbans={jest.fn()} />
+            <IbanDetailButtons active={active} iban={iban} deleteIban={jest.fn()} />
           </ThemeProvider>
         </Router>
       </Provider>

--- a/src/pages/iban/detail/components/IbanDetailButtons.tsx
+++ b/src/pages/iban/detail/components/IbanDetailButtons.tsx
@@ -8,52 +8,38 @@ import { IbanFormAction } from '../../../../model/Iban';
 type Props = {
   active: boolean | undefined;
   iban: string;
-  deleteIbans: () => Promise<void>;
+  deleteIban: () => Promise<void>;
 };
 
-const IbanDetailButtons = ({ active, iban, deleteIbans }: Props) => {
+const IbanDetailButtons = ({ active, iban, deleteIban }: Props) => {
   const { t } = useTranslation();
 
   return (
     <Stack spacing={2} direction="row" flexWrap={'wrap'} justifyContent={'flex-end'}>
+      <Button
+        color="error"
+        variant="outlined"
+        onClick={() => deleteIban()}
+        data-testid="delete-button-test"
+      >
+        {t('ibanDetailPage.buttons.delete')}
+      </Button>
       {!active ? (
-        <>
-          <Button
-            component={Link}
-            to={() => generatePath(ROUTES.IBAN)}
-            color="error"
-            variant="outlined"
-            onClick={() => deleteIbans()}
-            data-testid="delete-button-test"
-          >
-            {t('ibanDetailPage.buttons.delete')}
-          </Button>
-          <Button
-            component={Link}
-            to={() =>
-              generatePath(ROUTES.IBAN_EDIT, {
-                ibanId: iban,
-                actionId: IbanFormAction.Edit,
-              })
-            }
-            variant="contained"
-            data-testid="button Edit"
-          >
-            {t('ibanDetailPage.buttons.edit')}
-          </Button>
-        </>
+        <Button
+          component={Link}
+          to={() =>
+            generatePath(ROUTES.IBAN_EDIT, {
+              ibanId: iban,
+              actionId: IbanFormAction.Edit,
+            })
+          }
+          variant="contained"
+          data-testid="button Edit"
+        >
+          {t('ibanDetailPage.buttons.edit')}
+        </Button>
       ) : (
         <>
-          <Button
-            component={Link}
-            to={() => generatePath(ROUTES.IBAN)}
-            color="error"
-            variant="outlined"
-            onClick={() => deleteIbans()}
-            data-testid="delete-button-test"
-          >
-            {t('ibanDetailPage.buttons.delete')}
-          </Button>
           <Button component={Link} to={''} variant="outlined" disabled={true}>
             {t('ibanDetailPage.buttons.deactivate')}
           </Button>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Change the delete button's function to redirect the user only after receiving the delete response.
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The click on the 'Delete IBAN' button was redirecting the user to the IBANs page without waiting for the deletion to actually happen. Therefore, the just-deleted IBAN was still being displayed in the IBANs table. After a refresh, the IBANs table fetched the correct data.

#### How Has This Been Tested?
manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
