### PR TITLE
PASELC-537 refresh dashboard data after psp node signin

### DIFF
--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -104,6 +104,7 @@
       "errorMessageDesc": "Errore durante la creazione, ID Channel duplicato",
       "pspErrorMessageTitle": "Errore",
       "pspErrorMessageDesc": "Errore durante la creazione, PSP già censito",
+      "pspUpdateErrorMessageDesc": "Errore durante l'update del PSP",
       "ecErrorMessageTitle": "Errore",
       "ecErrorMessageDesc": "Errore durante la creazione, EC già censito",
       "ecUpdateErrorMessageDesc": "Errore durante la modifica dei dati",

--- a/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
@@ -97,15 +97,8 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
       if (pspNodeData) {
         try {
           /* TODO: fix whene updatePSP info will be available
-            await updatePSPInfo(selectedParty.fiscalCode, {
-            address: { ...formik.values },
-            businessName: selectedParty?.description ?? '',
-            creditorInstitutionCode: selectedParty?.fiscalCode ?? '',
-            enabled: true,
-            pspPayment: false,
-            reportingFtp: false,
-            reportingZip: false,
-          });
+            await updatePSPInfo(formik.values);
+          */
 
           if (selectedParty) {
             await updateSigninData(selectedParty);
@@ -114,7 +107,6 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
           history.push(ROUTES.HOME, {
             alertSuccessMessage: t('nodeSignInPage.form.seccesMessagePut'),
           });
-          */
         } catch (reason) {
           addError({
             id: 'NODE_SIGNIN_PSP_UPDATE',

--- a/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
@@ -191,6 +191,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
                     onChange={formik.handleChange}
                     error={formik.touched.name && Boolean(formik.errors.name)}
                     helperText={formik.touched.name && formik.errors.name}
+                    inputProps={{ 'data-testid': 'name-test' }}
                   />
                 </Grid>
                 <Grid container item xs={6}>
@@ -205,6 +206,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
                     onChange={formik.handleChange}
                     error={formik.touched.businessName && Boolean(formik.errors.businessName)}
                     helperText={formik.touched.businessName && formik.errors.businessName}
+                    inputProps={{ 'data-testid': 'businessName-test' }}
                   />
                 </Grid>
                 <Grid container item xs={6}>
@@ -219,6 +221,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
                     onChange={formik.handleChange}
                     error={formik.touched.fiscalCode && Boolean(formik.errors.fiscalCode)}
                     helperText={formik.touched.fiscalCode && formik.errors.fiscalCode}
+                    inputProps={{ 'data-testid': 'fiscalCode-test' }}
                   />
                 </Grid>
                 <Grid container item xs={6}>
@@ -233,6 +236,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
                     onChange={formik.handleChange}
                     error={formik.touched.abiCode && Boolean(formik.errors.abiCode)}
                     helperText={formik.touched.abiCode && formik.errors.abiCode}
+                    inputProps={{ 'data-testid': 'abiCode-test' }}
                   />
                 </Grid>
                 <Grid container item xs={6}>
@@ -247,6 +251,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
                     onChange={formik.handleChange}
                     error={formik.touched.pspCode && Boolean(formik.errors.pspCode)}
                     helperText={formik.touched.pspCode && formik.errors.pspCode}
+                    inputProps={{ 'data-testid': 'pspCode-test' }}
                   />
                 </Grid>
                 <Grid container item xs={6}>
@@ -256,7 +261,12 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
                     name="bicCode"
                     label={t('nodeSignInPage.form.pspFields.bicCode')}
                     size="small"
-                    inputProps={{ maxLength: 5, inputMode: 'numeric', pattern: '[0-9]*' }}
+                    inputProps={{
+                      maxLength: 5,
+                      inputMode: 'numeric',
+                      pattern: '[0-9]*',
+                      'data-testid': 'bicCode-test',
+                    }}
                     value={formik.values.bicCode}
                     onChange={(e) => handleChangeNumberOnly(e, 'bicCode', formik)}
                     error={formik.touched.bicCode && Boolean(formik.errors.bicCode)}
@@ -284,11 +294,13 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
                       value={false}
                       control={<Radio />}
                       label={t('nodeSignInPage.form.pspFields.digitalStamp.no')}
+                      data-testid="digitalStamp-false-test"
                     />
                     <FormControlLabel
                       value={true}
                       control={<Radio />}
                       label={t('nodeSignInPage.form.pspFields.digitalStamp.yes')}
+                      data-testid="digitalStamp-true-test"
                     />
                   </RadioGroup>
                 </Grid>
@@ -310,6 +322,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
               color="primary"
               variant="contained"
               type="submit"
+              data-testid="continue-button-test"
             >
               {t('nodeSignInPage.form.continueButton')}
             </Button>

--- a/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
@@ -93,36 +93,36 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
   const submit = async () => {
     setLoading(true);
 
-    if (selectedParty) {
-      if (pspNodeData) {
-        try {
-          /* TODO: fix whene updatePSP info will be available
-            await updatePSPInfo(formik.values);
-          */
+    if (selectedParty && pspNodeData) {
+      try {
+        /* TODO: fix whene updatePSP info will be available
+          await updatePSPInfo(formik.values);
+        */
 
-          if (selectedParty) {
-            await updateSigninData(selectedParty);
-          }
-
-          history.push(ROUTES.HOME, {
-            alertSuccessMessage: t('nodeSignInPage.form.seccesMessagePut'),
-          });
-        } catch (reason) {
-          addError({
-            id: 'NODE_SIGNIN_PSP_UPDATE',
-            blocking: false,
-            error: reason as Error,
-            techDescription: `An error occurred while updating PSP data on the node`,
-            toNotify: true,
-            displayableTitle: t('nodeSignInPage.form.pspErrorMessageTitle'),
-            displayableDescription: t('nodeSignInPage.form.pspUpdateErrorMessageDesc'),
-            component: 'Toast',
-          });
-        } finally {
-          setLoading(false);
+        if (selectedParty) {
+          await updateSigninData(selectedParty);
         }
+
+        history.push(ROUTES.HOME, {
+          alertSuccessMessage: t('nodeSignInPage.form.seccesMessagePut'),
+        });
+      } catch (reason) {
+        addError({
+          id: 'NODE_SIGNIN_PSP_UPDATE',
+          blocking: false,
+          error: reason as Error,
+          techDescription: `An error occurred while updating PSP data on the node`,
+          toNotify: true,
+          displayableTitle: t('nodeSignInPage.form.pspErrorMessageTitle'),
+          displayableDescription: t('nodeSignInPage.form.pspUpdateErrorMessageDesc'),
+          component: 'Toast',
+        });
+      } finally {
+        setLoading(false);
       }
-    } else {
+    }
+
+    if (selectedParty) {
       try {
         await createPSPDirect(formik.values);
 

--- a/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
@@ -118,7 +118,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
       }
     }
 
-    if (selectedParty) {
+    if (selectedParty && !pspNodeData) {
       try {
         await createPSPDirect(formik.values);
 

--- a/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
@@ -23,7 +23,7 @@ import { Party } from '../../../model/Party';
 import { LOADING_TASK_CHANNEL_ADD_EDIT } from '../../../utils/constants';
 import FormSectionTitle from '../../../components/Form/FormSectionTitle';
 import { NodeOnSignInPSP } from '../../../model/Node';
-import { createPSPDirect } from '../../../services/nodeService';
+import { createPSPDirect, updatePSPInfo } from '../../../services/nodeService';
 import { useSigninData } from '../../../hooks/useSigninData';
 import { PaymentServiceProviderDetailsResource } from '../../../api/generated/portal/PaymentServiceProviderDetailsResource';
 
@@ -95,13 +95,9 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
 
     if (selectedParty && pspNodeData) {
       try {
-        /* TODO: fix whene updatePSP info will be available
-          await updatePSPInfo(formik.values);
-        */
+        await updatePSPInfo(formik.values);
 
-        if (selectedParty) {
-          await updateSigninData(selectedParty);
-        }
+        await updateSigninData(selectedParty);
 
         history.push(ROUTES.HOME, {
           alertSuccessMessage: t('nodeSignInPage.form.seccesMessagePut'),
@@ -126,9 +122,7 @@ const NodeSignInPSPForm = ({ goBack, pspNodeData }: Props) => {
       try {
         await createPSPDirect(formik.values);
 
-        if (selectedParty) {
-          await updateSigninData(selectedParty);
-        }
+        await updateSigninData(selectedParty);
 
         history.push(ROUTES.HOME, {
           alertSuccessMessage: t('nodeSignInPage.form.successMessage'),

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
@@ -1,14 +1,14 @@
-import {ThemeProvider} from '@mui/system';
-import {theme} from '@pagopa/mui-italia';
-import {cleanup, fireEvent, render, screen} from '@testing-library/react';
-import {createMemoryHistory} from 'history';
+import { ThemeProvider } from '@mui/system';
+import { theme } from '@pagopa/mui-italia';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
-import {Provider} from 'react-redux';
-import {Router} from 'react-router-dom';
-import {store} from '../../../redux/store';
-import NodeSignInECForm from '../nodeSignIn/NodeSignInECForm';
-import {PortalApi} from '../../../api/PortalApiClient';
-import {CreditorInstitutionDetailsResource} from '../../../api/generated/portal/CreditorInstitutionDetailsResource';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import { store } from '../../../../redux/store';
+import NodeSignInECForm from '../NodeSignInECForm';
+import { PortalApi } from '../../../../api/PortalApiClient';
+import { CreditorInstitutionDetailsResource } from '../../../../api/generated/portal/CreditorInstitutionDetailsResource';
 
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
@@ -5,10 +5,52 @@ import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { store } from '../../../../redux/store';
+import { createStore, store } from '../../../../redux/store';
 import NodeSignInECForm from '../NodeSignInECForm';
 import { PortalApi } from '../../../../api/PortalApiClient';
 import { CreditorInstitutionDetailsResource } from '../../../../api/generated/portal/CreditorInstitutionDetailsResource';
+
+const renderApp = (
+  injectedStore?: ReturnType<typeof createStore>,
+  injectedHistory?: ReturnType<typeof createMemoryHistory>,
+  ecNodeData?: CreditorInstitutionDetailsResource
+) => {
+  const store = injectedStore ? injectedStore : createStore();
+  const history = injectedHistory ? injectedHistory : createMemoryHistory();
+  render(
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <Router history={history}>
+          <NodeSignInECForm goBack={jest.fn()} ecNodeData={ecNodeData} />
+        </Router>
+      </ThemeProvider>
+    </Provider>
+  );
+  return { store, history };
+};
+
+const setupForm = () => {
+  const address = screen.getByTestId('address-test') as HTMLInputElement;
+  const city = screen.getByTestId('city-test') as HTMLInputElement;
+  const province = screen.getByTestId('province-test') as HTMLSelectElement;
+  const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
+  const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
+
+  fireEvent.change(address, { target: { value: 'Via Calindri 21' } });
+  expect(address.value).toBe('Via Calindri 21');
+
+  fireEvent.change(city, { target: { value: 'Milano' } });
+  expect(city.value).toBe('Milano');
+
+  fireEvent.change(province, { target: { value: 'MI' } });
+  expect(province.value).toBe('MI');
+
+  fireEvent.change(CAP, { target: { value: '11111' } });
+  expect(CAP.value).toBe('11111');
+
+  fireEvent.change(fiscalDomicile, { target: { value: 'Via Calindri 21' } });
+  expect(fiscalDomicile.value).toBe('Via Calindri 21');
+};
 
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -21,108 +63,27 @@ describe('NodeSignInECForm', (injectedHistory?: ReturnType<typeof createMemoryHi
   const history = injectedHistory ? injectedHistory : createMemoryHistory();
 
   test('Test rendering NodeSignInECForm and Sumbit', async () => {
-    render(
-      <Provider store={store}>
-        <ThemeProvider theme={theme}>
-          <Router history={history}>
-            <NodeSignInECForm goBack={jest.fn()} />
-          </Router>
-        </ThemeProvider>
-      </Provider>
-    );
+    renderApp();
 
-    const address = screen.getByTestId('address-test') as HTMLInputElement;
-    const city = screen.getByTestId('city-test') as HTMLInputElement;
-    const province = screen.getByTestId('province-test') as HTMLSelectElement;
-    const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
-    const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
-
-    fireEvent.change(address, { target: { value: 'Via Calindri 21' } });
-    expect(address.value).toBe('Via Calindri 21');
-
-    fireEvent.change(city, { target: { value: 'Milano' } });
-    expect(city.value).toBe('Milano');
-
-    fireEvent.change(province, { target: { value: 'MI' } });
-    expect(province.value).toBe('MI');
-
-    fireEvent.change(CAP, { target: { value: '12345' } });
-    expect(CAP.value).toBe('12345');
-
-    fireEvent.change(fiscalDomicile, { target: { value: 'Via Calindri 21' } });
-    expect(fiscalDomicile.value).toBe('Via Calindri 21');
+    setupForm();
 
     const confirmBtn = await screen.findByTestId('continue-button-test');
     fireEvent.click(confirmBtn);
   });
 
   test('Test rendering NodeSignInECForm and Sumbit', async () => {
-    render(
-      <Provider store={store}>
-        <ThemeProvider theme={theme}>
-          <Router history={history}>
-            <NodeSignInECForm goBack={jest.fn()} />
-          </Router>
-        </ThemeProvider>
-      </Provider>
-    );
+    renderApp();
 
-    const address = screen.getByTestId('address-test') as HTMLInputElement;
-    const city = screen.getByTestId('city-test') as HTMLInputElement;
-    const province = screen.getByTestId('province-test') as HTMLSelectElement;
-    const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
-    const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
-
-    fireEvent.change(address, { target: { value: 'Via Calindri 21' } });
-    expect(address.value).toBe('Via Calindri 21');
-
-    fireEvent.change(city, { target: { value: 'Milano' } });
-    expect(city.value).toBe('Milano');
-
-    fireEvent.change(province, { target: { value: 'MI' } });
-    expect(province.value).toBe('MI');
-
-    fireEvent.change(CAP, { target: { value: '12345' } });
-    expect(CAP.value).toBe('12345');
-
-    fireEvent.change(fiscalDomicile, { target: { value: 'Via Calindri 21' } });
-    expect(fiscalDomicile.value).toBe('Via Calindri 21');
+    setupForm();
 
     const backBtn = await screen.findByTestId('back-button-test');
     fireEvent.click(backBtn);
   });
 
   test('Test rendering NodeSignInECForm and Sumbit', async () => {
-    render(
-      <Provider store={store}>
-        <ThemeProvider theme={theme}>
-          <Router history={history}>
-            <NodeSignInECForm goBack={jest.fn()} />
-          </Router>
-        </ThemeProvider>
-      </Provider>
-    );
+    renderApp();
 
-    const address = screen.getByTestId('address-test') as HTMLInputElement;
-    const city = screen.getByTestId('city-test') as HTMLInputElement;
-    const province = screen.getByTestId('province-test') as HTMLSelectElement;
-    const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
-    const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
-
-    fireEvent.change(address, { target: { value: 'Via Calindri 21' } });
-    expect(address.value).toBe('Via Calindri 21');
-
-    fireEvent.change(city, { target: { value: 'Milano' } });
-    expect(city.value).toBe('Milano');
-
-    fireEvent.change(province, { target: { value: 'MI' } });
-    expect(province.value).toBe('MI');
-
-    fireEvent.change(CAP, { target: { value: '11111' } });
-    expect(CAP.value).toBe('11111');
-
-    fireEvent.change(fiscalDomicile, { target: { value: 'Via Calindri 21' } });
-    expect(fiscalDomicile.value).toBe('Via Calindri 21');
+    setupForm();
 
     const confirmBtn = await screen.findByTestId('continue-button-test');
     fireEvent.click(confirmBtn);

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -15,7 +15,7 @@ let createPSPDirectMocked: jest.SpyInstance;
 let useSigninDataMocked: jest.SpyInstance;
 let updatePSPInfoMocked: jest.SpyInstance;
 
-jest.mock('../../../../decorators//withSelectedParty');
+jest.mock('../../../../decorators/withSelectedParty');
 
 const renderApp = (
   injectedStore?: ReturnType<typeof createStore>,
@@ -34,6 +34,30 @@ const renderApp = (
     </Provider>
   );
   return { store, history };
+};
+
+const setupFormAndSubmit = async (store) => {
+  await waitFor(() =>
+    store.dispatch({
+      type: 'parties/setPartySelected',
+      payload: pspPartySelected,
+    })
+  );
+  const name = screen.getByTestId('name-test') as HTMLInputElement;
+  const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
+  const fiscalCode = screen.getByTestId('fiscalCode-test') as HTMLSelectElement;
+  const abiCode = screen.getByTestId('abiCode-test') as HTMLInputElement;
+  const pspCode = screen.getByTestId('pspCode-test') as HTMLInputElement;
+  const bicCode = screen.getByTestId('bicCode-test') as HTMLInputElement;
+  const digitalStampRadioTrue = screen.getByTestId('digitalStamp-true-test');
+
+  fireEvent.change(bicCode, { target: { value: '1234' } });
+  expect(bicCode.value).toBe('1234');
+
+  fireEvent.click(digitalStampRadioTrue);
+
+  const confirmBtn = await screen.findByTestId('continue-button-test');
+  fireEvent.click(confirmBtn);
 };
 
 beforeEach(() => {
@@ -56,28 +80,7 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
   test('Test rendering NodeSignInPSPForm and Sumbit', async () => {
     const { store } = renderApp();
 
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setPartySelected',
-        payload: pspPartySelected,
-      })
-    );
-
-    const name = screen.getByTestId('name-test') as HTMLInputElement;
-    const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
-    const fiscalCode = screen.getByTestId('fiscalCode-test') as HTMLSelectElement;
-    const abiCode = screen.getByTestId('abiCode-test') as HTMLInputElement;
-    const pspCode = screen.getByTestId('pspCode-test') as HTMLInputElement;
-    const bicCode = screen.getByTestId('bicCode-test') as HTMLInputElement;
-    const digitalStampRadioTrue = screen.getByTestId('digitalStamp-true-test');
-
-    fireEvent.change(bicCode, { target: { value: '1234' } });
-    expect(bicCode.value).toBe('1234');
-
-    fireEvent.click(digitalStampRadioTrue);
-
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
+    await setupFormAndSubmit(store);
 
     await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(useSigninDataMocked).toHaveBeenCalled());
@@ -86,28 +89,8 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
   test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
     const { store } = renderApp(undefined, undefined, pspNodeData);
 
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setPartySelected',
-        payload: pspPartySelected,
-      })
-    );
+    await setupFormAndSubmit(store);
 
-    const name = screen.getByTestId('name-test') as HTMLInputElement;
-    const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
-    const fiscalCode = screen.getByTestId('fiscalCode-test') as HTMLSelectElement;
-    const abiCode = screen.getByTestId('abiCode-test') as HTMLInputElement;
-    const pspCode = screen.getByTestId('pspCode-test') as HTMLInputElement;
-    const bicCode = screen.getByTestId('bicCode-test') as HTMLInputElement;
-    const digitalStampRadioTrue = screen.getByTestId('digitalStamp-true-test');
-
-    fireEvent.change(bicCode, { target: { value: '1234' } });
-    expect(bicCode.value).toBe('1234');
-
-    fireEvent.click(digitalStampRadioTrue);
-
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
     await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalled());
     await waitFor(() => expect(updatePSPInfoMocked).toHaveBeenCalled());
   });

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -5,7 +5,7 @@ import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { store } from '../../../../redux/store';
+import { createStore, store } from '../../../../redux/store';
 import NodeSignInPSPForm from '../NodeSignInPSPForm';
 import { PortalApi } from '../../../../api/PortalApiClient';
 import { CreditorInstitutionDetailsResource } from '../../../../api/generated/portal/CreditorInstitutionDetailsResource';
@@ -13,6 +13,25 @@ import { PaymentServiceProviderDetailsResource } from '../../../../api/generated
 
 let createPSPDirectMocked: jest.SpyInstance;
 let useSigninDataMocked: jest.SpyInstance;
+
+const renderApp = (
+  injectedStore?: ReturnType<typeof createStore>,
+  injectedHistory?: ReturnType<typeof createMemoryHistory>,
+  pspNodeData?: PaymentServiceProviderDetailsResource
+) => {
+  const store = injectedStore ? injectedStore : createStore();
+  const history = injectedHistory ? injectedHistory : createMemoryHistory();
+  render(
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <Router history={history}>
+          <NodeSignInPSPForm goBack={jest.fn()} pspNodeData={pspNodeData} />
+        </Router>
+      </ThemeProvider>
+    </Provider>
+  );
+  return { store, history };
+};
 
 beforeEach(() => {
   createPSPDirectMocked = jest.spyOn(
@@ -31,15 +50,7 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
   const history = injectedHistory ? injectedHistory : createMemoryHistory();
 
   test('Test rendering NodeSignInPSPForm and Sumbit', async () => {
-    render(
-      <Provider store={store}>
-        <ThemeProvider theme={theme}>
-          <Router history={history}>
-            <NodeSignInPSPForm goBack={jest.fn()} />
-          </Router>
-        </ThemeProvider>
-      </Provider>
-    );
+    renderApp();
 
     const name = screen.getByTestId('name-test') as HTMLInputElement;
     const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
@@ -62,15 +73,7 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
   });
 
   test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
-    render(
-      <Provider store={store}>
-        <ThemeProvider theme={theme}>
-          <Router history={history}>
-            <NodeSignInPSPForm goBack={jest.fn()} pspNodeData={pspNodeData} />
-          </Router>
-        </ThemeProvider>
-      </Provider>
-    );
+    renderApp(undefined, undefined, pspNodeData);
 
     const name = screen.getByTestId('name-test') as HTMLInputElement;
     const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -86,12 +86,12 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
     await waitFor(() => expect(useSigninDataMocked).toHaveBeenCalled());
   });
 
-  test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
+  test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit the update', async () => {
     const { store } = renderApp(undefined, undefined, pspNodeData);
 
     await setupFormAndSubmit(store);
 
-    await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalled());
+    await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalledTimes(0));
     await waitFor(() => expect(updatePSPInfoMocked).toHaveBeenCalled());
   });
 });

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -14,6 +14,8 @@ import { PaymentServiceProviderDetailsResource } from '../../../../api/generated
 let createPSPDirectMocked: jest.SpyInstance;
 let useSigninDataMocked: jest.SpyInstance;
 
+jest.mock('../../../../decorators//withSelectedParty');
+
 const renderApp = (
   injectedStore?: ReturnType<typeof createStore>,
   injectedHistory?: ReturnType<typeof createMemoryHistory>,
@@ -50,7 +52,14 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
   const history = injectedHistory ? injectedHistory : createMemoryHistory();
 
   test('Test rendering NodeSignInPSPForm and Sumbit', async () => {
-    renderApp();
+    const { store } = renderApp();
+
+    await waitFor(() =>
+      store.dispatch({
+        type: 'parties/setPartySelected',
+        payload: pspPartySelected,
+      })
+    );
 
     const name = screen.getByTestId('name-test') as HTMLInputElement;
     const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
@@ -72,8 +81,15 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
     await waitFor(() => expect(useSigninDataMocked).toHaveBeenCalled());
   });
 
-  test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
-    renderApp(undefined, undefined, pspNodeData);
+  test.skip('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
+    const { store } = renderApp(undefined, undefined, pspNodeData);
+
+    await waitFor(() =>
+      store.dispatch({
+        type: 'parties/setPartySelected',
+        payload: pspPartySelected,
+      })
+    );
 
     const name = screen.getByTestId('name-test') as HTMLInputElement;
     const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
@@ -105,4 +121,32 @@ const pspNodeData: PaymentServiceProviderDetailsResource = {
   business_name: 'PSP S.r.l',
   enabled: true,
   psp_code: '12312312',
+};
+
+const pspPartySelected = {
+  partyId: '26a0aabf-ce6a-4dfa-af4e-d4f744a8b944',
+  externalId: '15376371009',
+  originId: 'PAGOPASPA',
+  origin: 'SELC',
+  description: 'PagoPA S.p.A.',
+  fiscalCode: '15376371009',
+  digitalAddress: 'selfcare@pec.pagopa.it',
+  status: 'ACTIVE',
+  registeredOffice: 'Piazza Colonna, 370',
+  institutionType: 'PSP',
+  roles: [
+    {
+      partyRole: 'DELEGATE',
+      roleKey: 'admin',
+    },
+  ],
+  urlLogo: 'http://checkout.selfcare/institutions/26a0aabf-ce6a-4dfa-af4e-d4f744a8b944/logo.png',
+  typology: 'TODO',
+  pspData: {
+    businessRegisterNumber: '00000000000',
+    legalRegisterName: 'ISTITUTI DI PAGAMENTO',
+    legalRegisterNumber: '09878',
+    abiCode: '36042',
+    vatNumberGroup: false,
+  },
 };

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -1,0 +1,50 @@
+import { ThemeProvider } from '@mui/system';
+import { theme } from '@pagopa/mui-italia';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import { store } from '../../../../redux/store';
+import NodeSignInPSPForm from '../NodeSignInPSPForm';
+import { PortalApi } from '../../../../api/PortalApiClient';
+import { CreditorInstitutionDetailsResource } from '../../../../api/generated/portal/CreditorInstitutionDetailsResource';
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(cleanup);
+
+describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryHistory>) => {
+  const history = injectedHistory ? injectedHistory : createMemoryHistory();
+
+  test('Test rendering NodeSignInPSPForm and Sumbit', async () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router history={history}>
+            <NodeSignInPSPForm goBack={jest.fn()} />
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    const name = screen.getByTestId('name-test') as HTMLInputElement;
+    const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
+    const fiscalCode = screen.getByTestId('fiscalCode-test') as HTMLSelectElement;
+    const abiCode = screen.getByTestId('abiCode-test') as HTMLInputElement;
+    const pspCode = screen.getByTestId('pspCode-test') as HTMLInputElement;
+    const bicCode = screen.getByTestId('bicCode-test') as HTMLInputElement;
+    const digitalStampRadioTrue = screen.getByTestId('digitalStamp-true-test');
+
+    fireEvent.change(bicCode, { target: { value: '1234' } });
+    expect(bicCode.value).toBe('1234');
+
+    fireEvent.click(digitalStampRadioTrue);
+
+    const confirmBtn = await screen.findByTestId('continue-button-test');
+    fireEvent.click(confirmBtn);
+  });
+});

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from '@mui/system';
 import { theme } from '@pagopa/mui-italia';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -9,8 +9,16 @@ import { store } from '../../../../redux/store';
 import NodeSignInPSPForm from '../NodeSignInPSPForm';
 import { PortalApi } from '../../../../api/PortalApiClient';
 import { CreditorInstitutionDetailsResource } from '../../../../api/generated/portal/CreditorInstitutionDetailsResource';
+import { PaymentServiceProviderDetailsResource } from '../../../../api/generated/portal/PaymentServiceProviderDetailsResource';
+
+let createPSPDirectMocked: jest.SpyInstance;
 
 beforeEach(() => {
+  createPSPDirectMocked = jest.spyOn(
+    require('../../../../services/nodeService'),
+    'createPSPDirect'
+  );
+
   jest.spyOn(console, 'error').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
 });
@@ -46,5 +54,49 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
 
     const confirmBtn = await screen.findByTestId('continue-button-test');
     fireEvent.click(confirmBtn);
+
+    await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalledTimes(1));
+  });
+
+  test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router history={history}>
+            <NodeSignInPSPForm goBack={jest.fn()} pspNodeData={pspNodeData} />
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    const name = screen.getByTestId('name-test') as HTMLInputElement;
+    const businessName = screen.getByTestId('businessName-test') as HTMLInputElement;
+    const fiscalCode = screen.getByTestId('fiscalCode-test') as HTMLSelectElement;
+    const abiCode = screen.getByTestId('abiCode-test') as HTMLInputElement;
+    const pspCode = screen.getByTestId('pspCode-test') as HTMLInputElement;
+    const bicCode = screen.getByTestId('bicCode-test') as HTMLInputElement;
+    const digitalStampRadioTrue = screen.getByTestId('digitalStamp-true-test');
+
+    fireEvent.change(bicCode, { target: { value: '1234' } });
+    expect(bicCode.value).toBe('1234');
+
+    fireEvent.click(digitalStampRadioTrue);
+
+    const confirmBtn = await screen.findByTestId('continue-button-test');
+    fireEvent.click(confirmBtn);
+    await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalledTimes(0));
   });
 });
+
+const pspNodeData: PaymentServiceProviderDetailsResource = {
+  abi: '12345',
+  agid_psp: true,
+  bic: '10101',
+  my_bank_code: '',
+  stamp: true,
+  tax_code: '123123',
+  vat_number: '12312312',
+  business_name: 'PSP S.r.l',
+  enabled: true,
+  psp_code: '12312312',
+};

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -13,6 +13,7 @@ import { PaymentServiceProviderDetailsResource } from '../../../../api/generated
 
 let createPSPDirectMocked: jest.SpyInstance;
 let useSigninDataMocked: jest.SpyInstance;
+let updatePSPInfoMocked: jest.SpyInstance;
 
 jest.mock('../../../../decorators//withSelectedParty');
 
@@ -41,6 +42,7 @@ beforeEach(() => {
     'createPSPDirect'
   );
   useSigninDataMocked = jest.spyOn(require('../../../../hooks/useSigninData'), 'useSigninData');
+  updatePSPInfoMocked = jest.spyOn(require('../../../../services/nodeService'), 'updatePSPInfo');
 
   jest.spyOn(console, 'error').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -81,7 +83,7 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
     await waitFor(() => expect(useSigninDataMocked).toHaveBeenCalled());
   });
 
-  test.skip('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
+  test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
     const { store } = renderApp(undefined, undefined, pspNodeData);
 
     await waitFor(() =>
@@ -107,6 +109,7 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
     const confirmBtn = await screen.findByTestId('continue-button-test');
     fireEvent.click(confirmBtn);
     await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalled());
+    await waitFor(() => expect(updatePSPInfoMocked).toHaveBeenCalled());
   });
 });
 

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -12,12 +12,14 @@ import { CreditorInstitutionDetailsResource } from '../../../../api/generated/po
 import { PaymentServiceProviderDetailsResource } from '../../../../api/generated/portal/PaymentServiceProviderDetailsResource';
 
 let createPSPDirectMocked: jest.SpyInstance;
+let useSigninDataMocked: jest.SpyInstance;
 
 beforeEach(() => {
   createPSPDirectMocked = jest.spyOn(
     require('../../../../services/nodeService'),
     'createPSPDirect'
   );
+  useSigninDataMocked = jest.spyOn(require('../../../../hooks/useSigninData'), 'useSigninData');
 
   jest.spyOn(console, 'error').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -56,6 +58,7 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
     fireEvent.click(confirmBtn);
 
     await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(useSigninDataMocked).toHaveBeenCalled());
   });
 
   test('Test rendering NodeSignInPSPForm with pspNodeData and Sumbit', async () => {
@@ -84,7 +87,7 @@ describe('NodeSignInPSPForm', (injectedHistory?: ReturnType<typeof createMemoryH
 
     const confirmBtn = await screen.findByTestId('continue-button-test');
     fireEvent.click(confirmBtn);
-    await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalledTimes(0));
+    await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalled());
   });
 });
 

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPage.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPage.test.tsx
@@ -18,17 +18,14 @@ beforeEach(() => {
   jest.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
-jest.mock('../../../../decorators/withLogin');
-jest.mock('../../../../decorators/withParties');
 jest.mock('../../../../decorators/withSelectedParty');
-jest.mock('../../../../decorators/withSelectedPartyProducts');
 
 const renderApp = (
   injectedStore?: ReturnType<typeof createStore>,
   injectedHistory?: ReturnType<typeof createMemoryHistory>
 ) => {
-  const store = injectedStore ? injectedStore : createStore();
   const history = injectedHistory ? injectedHistory : createMemoryHistory();
+  const store = injectedStore ? injectedStore : createStore();
   render(
     <Provider store={store}>
       <BrowserRouter>

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPage.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPage.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { Provider } from 'react-redux';
+import { createMemoryHistory } from 'history';
+// import { mockedParties } from '../services/__mocks__/partyService';
+import { ThemeProvider } from '@mui/material';
+import { theme } from '@pagopa/mui-italia';
+import '../../../../locale';
+import { BrowserRouter } from 'react-router-dom';
+
+import NodeSignInPage from '../NodeSignInPage';
+import { createStore } from '../../../../redux/store';
+import { Party } from '../../../../model/Party';
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+jest.mock('../../../../decorators/withLogin');
+jest.mock('../../../../decorators/withParties');
+jest.mock('../../../../decorators/withSelectedParty');
+jest.mock('../../../../decorators/withSelectedPartyProducts');
+
+const renderApp = (
+  injectedStore?: ReturnType<typeof createStore>,
+  injectedHistory?: ReturnType<typeof createMemoryHistory>
+) => {
+  const store = injectedStore ? injectedStore : createStore();
+  const history = injectedHistory ? injectedHistory : createMemoryHistory();
+  render(
+    <Provider store={store}>
+      <BrowserRouter>
+        <ThemeProvider theme={theme}>
+          <NodeSignInPage />
+        </ThemeProvider>
+      </BrowserRouter>
+    </Provider>
+  );
+  return { store, history };
+};
+
+test('Test rendering with psp', async () => {
+  const { store } = renderApp();
+  await waitFor(() =>
+    store.dispatch({
+      type: 'parties/setPartySelected',
+      payload: pspPartySelected,
+    })
+  );
+  expect(screen.getByText(/Marca da bollo digitale/i)).toBeVisible();
+});
+
+test('Test rendering with ec', async () => {
+  const { store } = renderApp();
+  await waitFor(() =>
+    store.dispatch({
+      type: 'parties/setPartySelected',
+      payload: ecPartySelected,
+    })
+  );
+  expect(screen.getAllByText(/Domicilio Fiscale/i).length).toBeGreaterThan(0);
+});
+
+const pspPartySelected: Party = {
+  partyId: '26a0aabf-ce6a-4dfa-af4e-d4f744a8b944',
+  externalId: '15376371009',
+  originId: 'PAGOPASPA',
+  origin: 'SELC',
+  description: 'PagoPA S.p.A.',
+  fiscalCode: '15376371009',
+  digitalAddress: 'selfcare@pec.pagopa.it',
+  status: 'ACTIVE',
+  registeredOffice: 'Piazza Colonna, 370',
+  institutionType: 'PSP',
+  roles: [
+    {
+      partyRole: 'DELEGATE',
+      roleKey: 'admin',
+    },
+  ],
+  urlLogo: 'http://checkout.selfcare/institutions/26a0aabf-ce6a-4dfa-af4e-d4f744a8b944/logo.png',
+  pspData: {
+    businessRegisterNumber: '00000000000',
+    legalRegisterName: 'ISTITUTI DI PAGAMENTO',
+    legalRegisterNumber: '09878',
+    abiCode: '36042',
+    vatNumberGroup: false,
+  },
+};
+
+const ecPartySelected: Party = {
+  partyId: '6b82300e-4fad-459d-a75b-91b5e7ae4f04',
+  externalId: '1122334455',
+  originId: 'c_g922',
+  origin: 'IPA',
+  institutionType: 'PA',
+  description: 'Ente Creditore S.r.l.',
+  category: 'Gestori di Pubblici Servizi',
+  fiscalCode: '1122334455',
+  digitalAddress: 'email-ec@test.dummy',
+  status: 'ACTIVE',
+  registeredOffice: 'Via degli Enti Creditori 1',
+  roles: [
+    {
+      partyRole: 'DELEGATE',
+      roleKey: 'admin',
+    },
+  ],
+  urlLogo: 'http://checkout.selfcare/institutions/6b82300e-4fad-459d-a75b-91b5e7ae4f04/logo.png',
+};

--- a/src/services/__mocks__/nodeService.ts
+++ b/src/services/__mocks__/nodeService.ts
@@ -68,6 +68,9 @@ const ecDirectUpdated: CreditorInstitutionDetailsResource = {
 export const createPSPDirect = (_psp: NodeOnSignInPSP): Promise<PSPDirectDTO> =>
   new Promise((resolve) => resolve(pspDirect));
 
+export const updatePSPInfo = (_psp: NodeOnSignInPSP): Promise<PSPDirectDTO> =>
+  new Promise((resolve) => resolve(pspDirect));
+
 export const getPSPDetails = (_pspcode: string): Promise<PaymentServiceProviderDetailsResource> =>
   new Promise((resolve) => resolve(pspDetails));
 

--- a/src/services/nodeService.ts
+++ b/src/services/nodeService.ts
@@ -12,6 +12,7 @@ import {
   createECAndBroker as createECAndBrokerMocked,
   createECDirect as createECDirectMocked,
   getECDetails as getCreditorInstitutionDetailsMocked,
+  updatePSPInfo as updatePSPInfoMocked,
   updateECDirect,
 } from './__mocks__/nodeService';
 
@@ -24,7 +25,8 @@ export const createPSPDirect = (psp: NodeOnSignInPSP): Promise<PSPDirectDTO> => 
   }
 };
 
-export const updatePSPInfo = (psp: NodeOnSignInPSP): Promise<PSPDirectDTO> => updatePSPInfo(psp);
+export const updatePSPInfo = (psp: NodeOnSignInPSP): Promise<PSPDirectDTO> =>
+  updatePSPInfoMocked(psp);
 
 // {
 /* istanbul ignore if */

--- a/src/services/nodeService.ts
+++ b/src/services/nodeService.ts
@@ -24,6 +24,17 @@ export const createPSPDirect = (psp: NodeOnSignInPSP): Promise<PSPDirectDTO> => 
   }
 };
 
+export const updatePSPInfo = (psp: NodeOnSignInPSP): Promise<PSPDirectDTO> => updatePSPInfo(psp);
+
+// {
+/* istanbul ignore if */
+// if (process.env.REACT_APP_API_MOCK_PORTAL === 'true') {
+// return updatePSPInfo(psp);
+/* } else {
+    return PortalApi.createPSPDirect(psp).then((resources) => resources);
+  } 
+}; */
+
 export const getPSPDetails = (pspcode: string): Promise<PaymentServiceProviderDetailsResource> => {
   /* istanbul ignore if */
   if (process.env.REACT_APP_API_MOCK_PORTAL === 'true') {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Update redux signin data after psp signin on the node so when redirecting user on dashboard, signin info will be freshly updated

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
After psp node signin, dashboard data wasn't updated

#### How Has This Been Tested?
manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
