### PR TITLE
PASELC-538 replace UAT selfcare url with the PROD url

### DIFF
--- a/.identity/03_github_environment.tf
+++ b/.identity/03_github_environment.tf
@@ -37,7 +37,7 @@ locals {
     "CDN_ENDPOINT" : "pagopa-${var.env_short}-selfcare-cdn-endpoint",
     "CDN_PROFILE" : "pagopa-${var.env_short}-selfcare-cdn-profile",
 
-    "SELFCARE_HOST_FE" : var.env == "prod" ? "https://selfcare.pagopa.it" : "https://${var.env}.selfcare.pagopa.it",
+    "SELFCARE_HOST_FE" : var.env == "prod" || var.env == "uat" ? "https://selfcare.pagopa.it" : "https://${var.env}.selfcare.pagopa.it",
     "SELFCARE_API_BE" : var.env == "prod" ? "https://api.platform.pagopa.it" : "https://api.${var.env}.platform.pagopa.it" ,
     "REACT_APP_URL_STORAGE" : "https://pagopa${var.env_short}selfcaresa.z6.web.core.windows.net/",
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Replace the selfcare URL in UAT with the PROD one

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When the user land on UAT Backoffice after PROD Login, should be able to go back to PROD Selfcare

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
