### PR TITLE
fix return value of ecBroker in case of get returns null

### DIFF
--- a/src/hooks/useSigninData.tsx
+++ b/src/hooks/useSigninData.tsx
@@ -32,7 +32,7 @@ const fetchSigninData = async (party: Party): Promise<SigninData> => {
       const ecAndBrokerDetails = await getBrokerAndEcDetails(party.fiscalCode);
       return {
         brokerPspDetailsResource: { ...pspBrokerDetails },
-        brokerDetailsResource: { ...ecAndBrokerDetails.brokerDetailsResource },
+        brokerDetailsResource: { ...(ecAndBrokerDetails?.brokerDetailsResource || {}) },
       };
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Fixed custom hook useSignInData to cover the case of getBrokerAndEcDetails returning null

#### Motivation and Context

- This fix is required because if the get of the ecDetails returns null and the get of pspBroker return the details, we were tryng to enter inside  a property of a null object, and this caused the problem where we were redirect inside of the catch case returning empty object instead of the psp broker details only.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
