### PR TITLE
PASELC-593 fix psp selection search single item clickability

### DIFF
--- a/src/pages/channels/channelAssociatePSP/PSPSelectionSearch.tsx
+++ b/src/pages/channels/channelAssociatePSP/PSPSelectionSearch.tsx
@@ -98,7 +98,7 @@ export default function PSPSelectionSearch({
               clearField={() => onPSPSelectionChange(undefined)}
             />
           ) : (
-            <CustomBox sx={{ pointerEvents: availablePSP.length !== 1 ? 'auto' : 'none' }}>
+            <CustomBox>
               {filteredParties &&
                 filteredParties.map((PSP) => (
                   <PSPItemContainer


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
remove point-event: none from PSPSelectionSearch
<!--- Describe your changes in detail -->

#### Motivation and Context
When there is only a PSP available to be associated to the channel, the searchBox doesn't allow selection via click that PSP
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
