### PR TITLE
[PASELC-508] feat: added modal for intermediation confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@
 
 ## To build a configured workspace execute the following command
 - yarn build
+
+## To execute a coverage check based on unit test execute the following command
+- yarn test:coverage

--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -131,6 +131,13 @@
       "backButton": "Annulla",
       "continueButton": "Conferma"
     },
+    "confirmIntermediaryModal": {
+      "title": "Disponibile come intermediario",
+      "messagePSP": "Confermi la tua disponibilità a intermediare PSP indiretti?",
+      "messageEC": "Confermi la tua disponibilità a intermediare EC indiretti?",
+      "confirmLabel": "Conferma",
+      "closeLabel": "Annulla"
+    },
     "validationMessage": {
       "requiredField": "Campo obbligatorio"
     }

--- a/src/pages/components/ConfirmModal.tsx
+++ b/src/pages/components/ConfirmModal.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Backdrop, Box, Button, Fade, Typography } from '@mui/material';
+import { Button, Stack, Typography } from '@mui/material';
 import { MouseEventHandler } from 'react';
 import GenericModal from '../../components/Form/GenericModal';
 import { isOperator } from './commonFunctions';
@@ -30,20 +29,9 @@ const ConfirmModal = ({
       <Typography variant="body1" sx={{ my: 2 }}>
         {message}
       </Typography>
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(6, 1fr)',
-          gridTemplateRows: 'auto',
-        }}
-      >
+      <Stack direction="row" spacing={2} justifyContent={'flex-end'} sx={{ mt: 3 }}>
         <Button
           variant="outlined"
-          sx={
-            operator
-              ? { gridColumn: 'span 5', justifySelf: 'end', mr: 4 }
-              : { gridColumn: 'span 5', justifySelf: 'end', mr: 2 }
-          }
           onClick={handleCloseConfirmModal}
           data-testid="cancel-button-modal-test"
         >
@@ -51,13 +39,12 @@ const ConfirmModal = ({
         </Button>
         <Button
           variant="contained"
-          sx={{ gridColumn: 'span 1', justifySelf: 'end' }}
           onClick={handleConfrimSubmit}
           data-testid="confirm-button-modal-test"
         >
           {onConfirmLabel}
         </Button>
-      </Box>
+      </Stack>
     </>
   );
 

--- a/src/pages/dashboard/nodeSignIn/NodeSignInECForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInECForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable complexity */
-import { useEffect } from 'react';
+import { ChangeEvent, useEffect } from 'react';
 import { useHistory } from 'react-router';
 import { Box, Button, Grid, Paper, Stack, TextField } from '@mui/material';
 import { FormikProps, useFormik } from 'formik';
@@ -26,19 +26,22 @@ import { createEcBroker } from '../../../services/nodeService';
 import { isEcBrokerSigned, isEcSigned, isPspBrokerSigned } from '../../../utils/rbac-utils';
 import CommonRadioGroup from './components/CommonRadioGroup';
 
+
 type Props = {
   goBack: () => void;
   signInData: BrokerAndEcDetailsResource;
+  handleChangeIntermediaryAvailable: (event:  ChangeEvent<HTMLInputElement> | undefined) => void;
+  intermediaryAvailableValue: boolean;
+  setIntermediaryAvailableValue: (value: boolean) => void;
 };
 
-const NodeSignInECForm = ({ goBack, signInData }: Props) => {
+const NodeSignInECForm = ({ goBack, signInData, handleChangeIntermediaryAvailable, intermediaryAvailableValue, setIntermediaryAvailableValue }: Props) => {
   const { t } = useTranslation();
   const history = useHistory();
   const addError = useErrorDispatcher();
   const setLoading = useLoading(LOADING_TASK_NODE_SIGN_IN_EC);
   const selectedParty = useAppSelector(partiesSelectors.selectPartySelected);
   const updateSigninData = useSigninData();
-  const [intermediaryAvailableValue, setIntermediaryAvailableValue] = useState<boolean>(false);
   const ecDirect = signInData && isEcBrokerSigned(signInData) && isEcSigned(signInData);
 
   useEffect(() => {
@@ -203,8 +206,6 @@ const NodeSignInECForm = ({ goBack, signInData }: Props) => {
     }
   };
 
-  const changeIntermediaryAvailable = () =>
-    setIntermediaryAvailableValue(!intermediaryAvailableValue);
 
   const enebledSubmit = (values: CreditorInstitutionAddressDto) =>
     !!(
@@ -332,7 +333,7 @@ const NodeSignInECForm = ({ goBack, signInData }: Props) => {
               labelTrue={t('nodeSignInPage.form.ecFields.intermediaryAvailable.yes')}
               labelFalse={t('nodeSignInPage.form.ecFields.intermediaryAvailable.no')}
               value={intermediaryAvailableValue}
-              onChange={changeIntermediaryAvailable}
+              onChange={(event:  ChangeEvent<HTMLInputElement> | undefined) => handleChangeIntermediaryAvailable(event)}
               ecDirect={ecDirect}
             />
           </Box>

--- a/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { theme } from '@pagopa/mui-italia';
 import { useErrorDispatcher, useLoading } from '@pagopa/selfcare-common-frontend';
 import { Badge as BadgeIcon, BookmarkAdd as BookmarkAddIcon } from '@mui/icons-material';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import ROUTES from '../../../routes';
 
 import { useAppSelector } from '../../../redux/hooks';
@@ -38,9 +38,12 @@ import CommonRadioGroup from './components/CommonRadioGroup';
 type Props = {
   goBack: () => void;
   signInData: BrokerOrPspDetailsResource;
+  handleChangeIntermediaryAvailable: (event:  ChangeEvent<HTMLInputElement> | undefined) => void;
+  intermediaryAvailableValue: boolean;
+  setIntermediaryAvailableValue: (value: boolean) => void;
 };
 
-const NodeSignInPSPForm = ({ goBack, signInData }: Props) => {
+const NodeSignInPSPForm = ({ goBack, signInData, handleChangeIntermediaryAvailable, intermediaryAvailableValue, setIntermediaryAvailableValue }: Props) => {
   const { t } = useTranslation();
   const history = useHistory();
   const addError = useErrorDispatcher();
@@ -49,7 +52,6 @@ const NodeSignInPSPForm = ({ goBack, signInData }: Props) => {
 
   const selectedParty = useAppSelector(partiesSelectors.selectPartySelected);
   const updateSigninData = useSigninData();
-  const [intermediaryAvailableValue, setIntermediaryAvailableValue] = useState<boolean>(false);
   const pspDirect = isPspBrokerSigned(signInData) && isPspSigned(signInData);
 
   useEffect(() => {
@@ -180,9 +182,6 @@ const NodeSignInPSPForm = ({ goBack, signInData }: Props) => {
       }
     }
   };
-
-  const changeIntermediaryAvailable = () =>
-    setIntermediaryAvailableValue(!intermediaryAvailableValue);
 
   const enebledSubmit = (values: NodeOnSignInPSP) =>
     values.bicCode !== '' &&
@@ -341,7 +340,7 @@ const NodeSignInPSPForm = ({ goBack, signInData }: Props) => {
                 labelTrue={t('nodeSignInPage.form.pspFields.intermediaryAvailable.yes')}
                 labelFalse={t('nodeSignInPage.form.pspFields.intermediaryAvailable.no')}
                 value={intermediaryAvailableValue}
-                onChange={changeIntermediaryAvailable}
+                onChange={(event:  ChangeEvent<HTMLInputElement> | undefined) => handleChangeIntermediaryAvailable(event)}
                 pspDirect={pspDirect}
               />
             </Box>

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
@@ -22,29 +22,18 @@ const renderApp = (
     signInData: BrokerAndEcDetailsResource,
     injectedStore?: ReturnType<typeof createStore>,
     injectedHistory?: ReturnType<typeof createMemoryHistory>,
-    intermediaryAvailable?: boolean,
-    setIntermediaryAvailable?: any,
-    handleChangeIntermediaryAvailable?: any
 ) => {
     const store = injectedStore ? injectedStore : createStore();
     const history = injectedHistory ? injectedHistory : createMemoryHistory();
-    intermediaryAvailable = false;
-    setIntermediaryAvailable = (value: boolean) => {
-        intermediaryAvailable = value
-    }
-    handleChangeIntermediaryAvailable = (event: ChangeEvent<HTMLInputElement> | undefined) => {
-        // @ts-ignore
-        setIntermediaryAvailable(!intermediaryAvailable);
-    }
 
     const {rerender} = render(
         <Provider store={store}>
             <ThemeProvider theme={theme}>
                 <Router history={history}>
                     <NodeSignInECForm goBack={jest.fn()} signInData={signInData}
-                                      handleChangeIntermediaryAvailable={handleChangeIntermediaryAvailable}
-                                      intermediaryAvailableValue={intermediaryAvailable}
-                                      setIntermediaryAvailableValue={setIntermediaryAvailable}/>
+                                      handleChangeIntermediaryAvailable={jest.fn}
+                                      intermediaryAvailableValue={false}
+                                      setIntermediaryAvailableValue={jest.fn}/>
                 </Router>
             </ThemeProvider>
         </Provider>

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
@@ -30,7 +30,7 @@ const renderApp = (
     <Provider store={store}>
       <ThemeProvider theme={theme}>
         <Router history={history}>
-          <NodeSignInECForm goBack={jest.fn()} signInData={signInData} />
+          <NodeSignInECForm goBack={jest.fn()} signInData={signInData} handleChangeIntermediaryAvailable={jest.fn()} intermediaryAvailableValue={false} setIntermediaryAvailableValue={jest.fn()} />
         </Router>
       </ThemeProvider>
     </Provider>

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
@@ -1,410 +1,459 @@
-import { ThemeProvider } from '@mui/system';
-import { theme } from '@pagopa/mui-italia';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
-import React from 'react';
-import { Provider } from 'react-redux';
-import { Router } from 'react-router-dom';
-import { createStore } from '../../../../redux/store';
+import {ThemeProvider} from '@mui/system';
+import {theme} from '@pagopa/mui-italia';
+import {cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {createMemoryHistory} from 'history';
+import React, {ChangeEvent} from 'react';
+import {Provider} from 'react-redux';
+import {Router} from 'react-router-dom';
+import {createStore} from '../../../../redux/store';
 import NodeSignInECForm from '../NodeSignInECForm';
-import { BrokerAndEcDetailsResource } from '../../../../api/generated/portal/BrokerAndEcDetailsResource';
+import {BrokerAndEcDetailsResource} from '../../../../api/generated/portal/BrokerAndEcDetailsResource';
 import {
-  brokerAndEcDetailsResource_ECAndBroker,
-  brokerAndEcDetailsResource_ECOnly,
-  ecDetails,
+    brokerAndEcDetailsResource_ECAndBroker,
+    brokerAndEcDetailsResource_ECOnly,
 } from '../../../../services/__mocks__/nodeService';
 import {
-  ecAdminSignedDirect,
-  ecAdminSignedUndirect,
-  ecAdminUnsigned,
+    ecAdminSignedDirect,
+    ecAdminSignedUndirect,
+    ecAdminUnsigned,
 } from '../../../../services/__mocks__/partyService';
 
 const renderApp = (
-  signInData: BrokerAndEcDetailsResource,
-  injectedStore?: ReturnType<typeof createStore>,
-  injectedHistory?: ReturnType<typeof createMemoryHistory>
+    signInData: BrokerAndEcDetailsResource,
+    injectedStore?: ReturnType<typeof createStore>,
+    injectedHistory?: ReturnType<typeof createMemoryHistory>,
+    intermediaryAvailable?: boolean,
+    setIntermediaryAvailable?: any,
+    handleChangeIntermediaryAvailable?: any
 ) => {
-  const store = injectedStore ? injectedStore : createStore();
-  const history = injectedHistory ? injectedHistory : createMemoryHistory();
-  render(
-    <Provider store={store}>
-      <ThemeProvider theme={theme}>
-        <Router history={history}>
-          <NodeSignInECForm goBack={jest.fn()} signInData={signInData} handleChangeIntermediaryAvailable={jest.fn()} intermediaryAvailableValue={false} setIntermediaryAvailableValue={jest.fn()} />
-        </Router>
-      </ThemeProvider>
-    </Provider>
-  );
-  return { store, history };
+    const store = injectedStore ? injectedStore : createStore();
+    const history = injectedHistory ? injectedHistory : createMemoryHistory();
+    intermediaryAvailable = false;
+    setIntermediaryAvailable = (value: boolean) => {
+        intermediaryAvailable = value
+    }
+    handleChangeIntermediaryAvailable = (event: ChangeEvent<HTMLInputElement> | undefined) => {
+        // @ts-ignore
+        setIntermediaryAvailable(!intermediaryAvailable);
+    }
+
+    const {rerender} = render(
+        <Provider store={store}>
+            <ThemeProvider theme={theme}>
+                <Router history={history}>
+                    <NodeSignInECForm goBack={jest.fn()} signInData={signInData}
+                                      handleChangeIntermediaryAvailable={handleChangeIntermediaryAvailable}
+                                      intermediaryAvailableValue={intermediaryAvailable}
+                                      setIntermediaryAvailableValue={setIntermediaryAvailable}/>
+                </Router>
+            </ThemeProvider>
+        </Provider>
+    );
+    return {store, history, rerender};
 };
 
 const setupForm = () => {
-  const address = screen.getByTestId('address-test') as HTMLInputElement;
-  const city = screen.getByTestId('city-test') as HTMLInputElement;
-  const province = screen.getByTestId('province-test') as HTMLSelectElement;
-  const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
-  const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
+    const address = screen.getByTestId('address-test') as HTMLInputElement;
+    const city = screen.getByTestId('city-test') as HTMLInputElement;
+    const province = screen.getByTestId('province-test') as HTMLSelectElement;
+    const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
+    const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
 
-  fireEvent.change(address, { target: { value: 'Via Calindri 21' } });
-  expect(address.value).toBe('Via Calindri 21');
+    fireEvent.change(address, {target: {value: 'Via Calindri 21'}});
+    expect(address.value).toBe('Via Calindri 21');
 
-  fireEvent.change(city, { target: { value: 'Milano' } });
-  expect(city.value).toBe('Milano');
+    fireEvent.change(city, {target: {value: 'Milano'}});
+    expect(city.value).toBe('Milano');
 
-  fireEvent.change(province, { target: { value: 'MI' } });
-  expect(province.value).toBe('MI');
+    fireEvent.change(province, {target: {value: 'MI'}});
+    expect(province.value).toBe('MI');
 
-  fireEvent.change(CAP, { target: { value: '11111' } });
-  expect(CAP.value).toBe('11111');
+    fireEvent.change(CAP, {target: {value: '11111'}});
+    expect(CAP.value).toBe('11111');
 
-  fireEvent.change(fiscalDomicile, { target: { value: 'Via Calindri 21' } });
-  expect(fiscalDomicile.value).toBe('Via Calindri 21');
+    fireEvent.change(fiscalDomicile, {target: {value: 'Via Calindri 21'}});
+    expect(fiscalDomicile.value).toBe('Via Calindri 21');
 };
 
-let spyOnCreateECAndBroker;
-let spyOnCreateEcIndirect;
-let spyOnUpdateCreditorInstitution;
-let SpyOnCreateEcBroker;
+let spyOnCreateECAndBroker: jest.SpyInstance<any, unknown[]>;
+let spyOnCreateEcIndirect: jest.SpyInstance<any, unknown[]>;
+let spyOnUpdateCreditorInstitution: jest.SpyInstance<any, unknown[]>;
+let SpyOnCreateEcBroker: jest.SpyInstance<any, unknown[]>;
 
 beforeEach(() => {
-  spyOnCreateECAndBroker = jest.spyOn(
-    require('../../../../services/nodeService'),
-    'createECAndBroker'
-  );
-  spyOnCreateEcIndirect = jest.spyOn(
-    require('../../../../services/nodeService'),
-    'createECIndirect'
-  );
-  spyOnUpdateCreditorInstitution = jest.spyOn(
-    require('../../../../services/nodeService'),
-    'updateCreditorInstitution'
-  );
-  SpyOnCreateEcBroker = jest.spyOn(require('../../../../services/nodeService'), 'createEcBroker');
+    spyOnCreateECAndBroker = jest.spyOn(
+        require('../../../../services/nodeService'),
+        'createECAndBroker'
+    );
+    spyOnCreateEcIndirect = jest.spyOn(
+        require('../../../../services/nodeService'),
+        'createECIndirect'
+    );
+    spyOnUpdateCreditorInstitution = jest.spyOn(
+        require('../../../../services/nodeService'),
+        'updateCreditorInstitution'
+    );
+    SpyOnCreateEcBroker = jest.spyOn(require('../../../../services/nodeService'), 'createEcBroker');
 
-  jest.spyOn(console, 'error').mockImplementation(() => {});
-  jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {
+    });
+    jest.spyOn(console, 'warn').mockImplementation(() => {
+    });
 });
 
 afterEach(cleanup);
 
 describe('NodeSignInECForm', () => {
-  const dispatchAdminUsignedAndSignInDataEmpty = async (store) => {
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setPartySelected',
-        payload: ecAdminUnsigned,
-      })
-    );
+    const dispatchAdminUsignedAndSignInDataEmpty = async (store: any) => {
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: ecAdminUnsigned,
+            })
+        );
 
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setSigninData',
-        payload: {},
-      })
-    );
-  };
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setSigninData',
+                payload: {},
+            })
+        );
+    };
 
-  const dispatchAdminSignedIndirectAndEcDetailsOnly = async (store) => {
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setPartySelected',
-        payload: ecAdminSignedUndirect,
-      })
-    );
+    const dispatchAdminSignedIndirectAndEcDetailsOnly = async (store) => {
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: ecAdminSignedUndirect,
+            })
+        );
 
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setSigninData',
-        payload: brokerAndEcDetailsResource_ECOnly,
-      })
-    );
-  };
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setSigninData',
+                payload: brokerAndEcDetailsResource_ECOnly,
+            })
+        );
+    };
 
-  const dispatchAdminSignedInDirectAndFullEcDetails = async (store) => {
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setPartySelected',
-        payload: ecAdminSignedDirect,
-      })
-    );
+    const dispatchAdminSignedInDirectAndFullEcDetails = async (store) => {
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: ecAdminSignedDirect,
+            })
+        );
 
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setSigninData',
-        payload: brokerAndEcDetailsResource_ECAndBroker,
-      })
-    );
-  };
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setSigninData',
+                payload: brokerAndEcDetailsResource_ECAndBroker,
+            })
+        );
+    };
 
-  test('Test rendering NodeSignInECForm with intermediary true and Sumbit a direct ec', async () => {
-    const { store } = renderApp({});
+    test('Test rendering NodeSignInECForm with intermediary true and Sumbit a direct ec', async () => {
+        const {store, history, rerender} = renderApp({});
 
-    dispatchAdminUsignedAndSignInDataEmpty(store);
+        dispatchAdminUsignedAndSignInDataEmpty(store);
 
-    setupForm();
+        setupForm();
 
-    const intermediaryTrue = screen
-      .getByTestId('intermediary-available-test')
-      .querySelector('[value=true]') as HTMLInputElement;
+        const intermediaryTrue = screen
+            .getByTestId('intermediary-available-test')
+            .querySelector('[value=true]') as HTMLInputElement;
 
-    fireEvent.click(intermediaryTrue);
+        fireEvent.click(intermediaryTrue);
 
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
+        rerender( <Provider store={store}>
+            <ThemeProvider theme={theme}>
+                <Router history={history}>
+                    <NodeSignInECForm goBack={jest.fn()} signInData={{}}
+                                      handleChangeIntermediaryAvailable={jest.fn()}
+                                      intermediaryAvailableValue={true}
+                                      setIntermediaryAvailableValue={jest.fn()}/>
+                </Router>
+            </ThemeProvider>
+        </Provider>);
 
-    await waitFor(() => {
-      expect(spyOnCreateECAndBroker).toHaveBeenCalled();
-    });
-  });
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
 
-  test('Test rendering NodeSignInECForm with intermediary false and Sumbit an inderiect ec', async () => {
-    const ecDetailsDispatched = {};
-
-    const { store } = renderApp(ecDetailsDispatched);
-
-    dispatchAdminUsignedAndSignInDataEmpty(store);
-
-    setupForm();
-
-    const intermediaryFalse = screen
-      .getByTestId('intermediary-available-test')
-      .querySelector('[value=false]') as HTMLInputElement;
-
-    fireEvent.click(intermediaryFalse);
-
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-
-    await waitFor(() => expect(spyOnCreateEcIndirect).toHaveBeenCalled());
-  });
-
-  test('Test rendering NodeSignInECForm and BackBtn click', async () => {
-    renderApp({});
-    const backBtn = await screen.findByTestId('back-button-test');
-    fireEvent.click(backBtn);
-  });
-
-  test('Test rendering NodeSignInECForm with intermediary true and create ecBroker', async () => {
-    const { store } = renderApp(brokerAndEcDetailsResource_ECOnly);
-
-    await waitFor(() => dispatchAdminSignedIndirectAndEcDetailsOnly(store));
-
-    const intermediaryTrue = screen
-      .getByTestId('intermediary-available-test')
-      .querySelector('[value=true]') as HTMLInputElement;
-
-    fireEvent.click(intermediaryTrue);
-
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-
-    await waitFor(() => {
-      expect(SpyOnCreateEcBroker).toHaveBeenCalled();
-    });
-  });
-
-  test('Test rendering NodeSignInECForm in case of updating the form with an ec direct', async () => {
-    const { store } = renderApp(brokerAndEcDetailsResource_ECAndBroker);
-
-    dispatchAdminSignedInDirectAndFullEcDetails(store);
-
-    const address = screen.getByTestId('address-test') as HTMLInputElement;
-    const city = screen.getByTestId('city-test') as HTMLInputElement;
-    const province = screen.getByTestId('province-test') as HTMLSelectElement;
-    const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
-    const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
-
-    expect(address.value).toBe(
-      brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.location
-    );
-    expect(city.value).toBe(
-      brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.city
-    );
-    expect(province.value).toBe(
-      brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.countryCode
-    );
-    expect(CAP.value).toBe(
-      brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.zipCode
-    );
-    expect(fiscalDomicile.value).toBe(
-      brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.taxDomicile
-    );
-
-    fireEvent.change(address, { target: { value: 'Via Roma 11' } });
-    expect(address.value).toBe('Via Roma 11');
-
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-
-    await waitFor(() => {
-      expect(spyOnUpdateCreditorInstitution).toHaveBeenCalled();
-    });
-  });
-
-  test('Test rendering NodeSignInECForm in case of updating the form with an ec indirect', async () => {
-    const { store } = renderApp(brokerAndEcDetailsResource_ECOnly);
-
-    await waitFor(() => dispatchAdminSignedIndirectAndEcDetailsOnly(store));
-
-    const address = screen.getByTestId('address-test') as HTMLInputElement;
-    const city = screen.getByTestId('city-test') as HTMLInputElement;
-    const province = screen.getByTestId('province-test') as HTMLSelectElement;
-    const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
-    const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
-    const intermediaryTrue = screen
-      .getByTestId('intermediary-available-test')
-      .querySelector('[value=true]') as HTMLInputElement;
-    const intermediaryFalse = screen
-      .getByTestId('intermediary-available-test')
-      .querySelector('[value=false]') as HTMLInputElement;
-
-    expect(address.value).toBe(
-      brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.location
-    );
-    expect(city.value).toBe(
-      brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.city
-    );
-    expect(province.value).toBe(
-      brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.countryCode
-    );
-    expect(CAP.value).toBe(
-      brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.zipCode
-    );
-    expect(fiscalDomicile.value).toBe(
-      brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.taxDomicile
-    );
-
-    expect(intermediaryFalse.checked).toBe(true);
-
-    fireEvent.change(address, { target: { value: 'Via Roma 11' } });
-    expect(address.value).toBe('Via Roma 11');
-
-    expect(intermediaryTrue.checked).toBe(false);
-    fireEvent.click(intermediaryTrue);
-    expect(intermediaryTrue.checked).toBe(true);
-
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-
-    await waitFor(() => expect(SpyOnCreateEcBroker).toHaveBeenCalled());
-    await waitFor(() => expect(spyOnUpdateCreditorInstitution).toHaveBeenCalled());
-  });
-
-  test('Test NodeSignInECForm function falsy conditions', async () => {
-    const { store } = renderApp({});
-
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setPartySelected',
-        payload: {
-          ...ecAdminUnsigned,
-          description: undefined,
-          fiscalCode: undefined,
-        },
-      })
-    );
-
-    await waitFor(() =>
-      store.dispatch({
-        type: 'parties/setSigninData',
-        payload: undefined,
-      })
-    );
-
-    setupForm();
-
-    const province = screen.getByTestId('province-test') as HTMLSelectElement;
-    const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-
-    fireEvent.change(province, { target: { value: 'M' } });
-    expect(province.value).toBe('M');
-
-    fireEvent.change(province, { target: { value: '12' } });
-    expect(province.value).toBe('M');
-
-    fireEvent.change(CAP, { target: { value: '1111' } });
-    expect(CAP.value).toBe('1111');
-
-    fireEvent.change(CAP, { target: { value: 'AAAAA' } });
-    expect(CAP.value).toBe('1111');
-
-    fireEvent.click(confirmBtn);
-
-    setupForm();
-
-    fireEvent.click(confirmBtn);
-  });
-
-  test('Test error response of createECAndBroker', async () => {
-    const { store } = renderApp({});
-
-    dispatchAdminUsignedAndSignInDataEmpty(store);
-
-    setupForm();
-
-    const intermediaryTrue = screen
-      .getByTestId('intermediary-available-test')
-      .querySelector('[value=true]') as HTMLInputElement;
-
-    fireEvent.click(intermediaryTrue);
-
-    spyOnCreateECAndBroker.mockRejectedValue(() => {
-      throw new Error('Error in createECAndBroker');
+        await waitFor(() => {
+            expect(spyOnCreateECAndBroker).toHaveBeenCalled();
+        });
     });
 
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-  });
+    test('Test rendering NodeSignInECForm with intermediary false and Sumbit an inderiect ec', async () => {
+        const ecDetailsDispatched = {};
 
-  test('Test error response of createECIndirect', async () => {
-    const { store } = renderApp({});
+        const {store} = renderApp(ecDetailsDispatched);
 
-    dispatchAdminUsignedAndSignInDataEmpty(store);
+        dispatchAdminUsignedAndSignInDataEmpty(store);
 
-    setupForm();
+        setupForm();
 
-    spyOnCreateEcIndirect.mockRejectedValue(() => {
-      throw new Error('Error in createECIndirect');
+        const intermediaryFalse = screen
+            .getByTestId('intermediary-available-test')
+            .querySelector('[value=false]') as HTMLInputElement;
+
+        fireEvent.click(intermediaryFalse);
+
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+
+        await waitFor(() => expect(spyOnCreateEcIndirect).toHaveBeenCalled());
     });
 
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-  });
-
-  test('Test error response of updateCreditorInstitution with intermediary true', async () => {
-    const { store } = renderApp(brokerAndEcDetailsResource_ECAndBroker);
-
-    dispatchAdminSignedInDirectAndFullEcDetails(store);
-
-    const address = screen.getByTestId('address-test') as HTMLInputElement;
-
-    fireEvent.change(address, { target: { value: 'Via Roma 11' } });
-    expect(address.value).toBe('Via Roma 11');
-
-    spyOnUpdateCreditorInstitution.mockRejectedValue(() => {
-      throw new Error('Error in updateCreditorInstitution');
+    test('Test rendering NodeSignInECForm and BackBtn click', async () => {
+        renderApp({});
+        const backBtn = await screen.findByTestId('back-button-test');
+        fireEvent.click(backBtn);
     });
 
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-  });
+    test('Test rendering NodeSignInECForm with intermediary true and create ecBroker', async () => {
+        const {store, history, rerender} = renderApp(brokerAndEcDetailsResource_ECOnly);
 
-  test('Test error response of updateCreditorInstitution with intermediary false', async () => {
-    const { store } = renderApp(brokerAndEcDetailsResource_ECOnly);
+        await waitFor(() => dispatchAdminSignedIndirectAndEcDetailsOnly(store));
 
-    await waitFor(() => dispatchAdminSignedIndirectAndEcDetailsOnly(store));
+        const intermediaryTrue = screen
+            .getByTestId('intermediary-available-test')
+            .querySelector('[value=true]') as HTMLInputElement;
 
-    const address = screen.getByTestId('address-test') as HTMLInputElement;
+        fireEvent.click(intermediaryTrue);
 
-    fireEvent.change(address, { target: { value: 'Via Roma 11' } });
-    expect(address.value).toBe('Via Roma 11');
+        rerender( <Provider store={store}>
+            <ThemeProvider theme={theme}>
+                <Router history={history}>
+                    <NodeSignInECForm goBack={jest.fn()} signInData={brokerAndEcDetailsResource_ECOnly}
+                                      handleChangeIntermediaryAvailable={jest.fn()}
+                                      intermediaryAvailableValue={true}
+                                      setIntermediaryAvailableValue={jest.fn()}/>
+                </Router>
+            </ThemeProvider>
+        </Provider>);
 
-    spyOnUpdateCreditorInstitution.mockRejectedValue(() => {
-      throw new Error('Error in updateCreditorInstitution');
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+
+        await waitFor(() => {
+            expect(SpyOnCreateEcBroker).toHaveBeenCalled();
+        });
     });
 
-    const confirmBtn = await screen.findByTestId('continue-button-test');
-    fireEvent.click(confirmBtn);
-  });
+    test('Test rendering NodeSignInECForm in case of updating the form with an ec direct', async () => {
+        const {store} = renderApp(brokerAndEcDetailsResource_ECAndBroker);
+
+        dispatchAdminSignedInDirectAndFullEcDetails(store);
+
+        const address = screen.getByTestId('address-test') as HTMLInputElement;
+        const city = screen.getByTestId('city-test') as HTMLInputElement;
+        const province = screen.getByTestId('province-test') as HTMLSelectElement;
+        const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
+        const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
+
+        expect(address.value).toBe(
+            brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.location
+        );
+        expect(city.value).toBe(
+            brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.city
+        );
+        expect(province.value).toBe(
+            brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.countryCode
+        );
+        expect(CAP.value).toBe(
+            brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.zipCode
+        );
+        expect(fiscalDomicile.value).toBe(
+            brokerAndEcDetailsResource_ECAndBroker.creditorInstitutionDetailsResource?.address.taxDomicile
+        );
+
+        fireEvent.change(address, {target: {value: 'Via Roma 11'}});
+        expect(address.value).toBe('Via Roma 11');
+
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+
+        await waitFor(() => {
+            expect(spyOnUpdateCreditorInstitution).toHaveBeenCalled();
+        });
+    });
+
+    test('Test rendering NodeSignInECForm in case of updating the form with an ec indirect', async () => {
+        const {store, history, rerender} = renderApp(brokerAndEcDetailsResource_ECOnly);
+
+
+        await waitFor(() => dispatchAdminSignedIndirectAndEcDetailsOnly(store));
+
+        const address = screen.getByTestId('address-test') as HTMLInputElement;
+        const city = screen.getByTestId('city-test') as HTMLInputElement;
+        const province = screen.getByTestId('province-test') as HTMLSelectElement;
+        const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
+        const fiscalDomicile = screen.getByTestId('fiscal-domicile-test') as HTMLInputElement;
+        const intermediaryTrue = screen
+            .getByTestId('intermediary-available-test')
+            .querySelector('[value=true]') as HTMLInputElement;
+        const intermediaryFalse = screen
+            .getByTestId('intermediary-available-test')
+            .querySelector('[value=false]') as HTMLInputElement;
+
+        expect(address.value).toBe(
+            brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.location
+        );
+        expect(city.value).toBe(
+            brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.city
+        );
+        expect(province.value).toBe(
+            brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.countryCode
+        );
+        expect(CAP.value).toBe(
+            brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.zipCode
+        );
+        expect(fiscalDomicile.value).toBe(
+            brokerAndEcDetailsResource_ECOnly.creditorInstitutionDetailsResource?.address.taxDomicile
+        );
+
+        expect(intermediaryFalse.checked).toBe(true);
+
+        fireEvent.change(address, {target: {value: 'Via Roma 11'}});
+        expect(address.value).toBe('Via Roma 11');
+
+        expect(intermediaryTrue.checked).toBe(false);
+        fireEvent.click(intermediaryTrue);
+        rerender( <Provider store={store}>
+            <ThemeProvider theme={theme}>
+                <Router history={history}>
+                    <NodeSignInECForm goBack={jest.fn()} signInData={brokerAndEcDetailsResource_ECOnly}
+                                      handleChangeIntermediaryAvailable={jest.fn()}
+                                      intermediaryAvailableValue={true}
+                                      setIntermediaryAvailableValue={jest.fn()}/>
+                </Router>
+            </ThemeProvider>
+        </Provider>);
+        expect(intermediaryTrue.checked).toBe(true);
+
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+
+        await waitFor(() => expect(SpyOnCreateEcBroker).toHaveBeenCalled());
+        await waitFor(() => expect(spyOnUpdateCreditorInstitution).toHaveBeenCalled());
+    });
+
+    test('Test NodeSignInECForm function falsy conditions', async () => {
+        const {store} = renderApp({});
+
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: {
+                    ...ecAdminUnsigned,
+                    description: undefined,
+                    fiscalCode: undefined,
+                },
+            })
+        );
+
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setSigninData',
+                payload: undefined,
+            })
+        );
+
+        setupForm();
+
+        const province = screen.getByTestId('province-test') as HTMLSelectElement;
+        const CAP = screen.getByTestId('CAP-test') as HTMLInputElement;
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+
+        fireEvent.change(province, {target: {value: 'M'}});
+        expect(province.value).toBe('M');
+
+        fireEvent.change(province, {target: {value: '12'}});
+        expect(province.value).toBe('M');
+
+        fireEvent.change(CAP, {target: {value: '1111'}});
+        expect(CAP.value).toBe('1111');
+
+        fireEvent.change(CAP, {target: {value: 'AAAAA'}});
+        expect(CAP.value).toBe('1111');
+
+        fireEvent.click(confirmBtn);
+
+        setupForm();
+
+        fireEvent.click(confirmBtn);
+    });
+
+    test('Test error response of createECAndBroker', async () => {
+        const {store} = renderApp({});
+
+        dispatchAdminUsignedAndSignInDataEmpty(store);
+
+        setupForm();
+
+        const intermediaryTrue = screen
+            .getByTestId('intermediary-available-test')
+            .querySelector('[value=true]') as HTMLInputElement;
+
+        fireEvent.click(intermediaryTrue);
+
+        spyOnCreateECAndBroker.mockRejectedValue(() => {
+            throw new Error('Error in createECAndBroker');
+        });
+
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+    });
+
+    test('Test error response of createECIndirect', async () => {
+        const {store} = renderApp({});
+
+        dispatchAdminUsignedAndSignInDataEmpty(store);
+
+        setupForm();
+
+        spyOnCreateEcIndirect.mockRejectedValue(() => {
+            throw new Error('Error in createECIndirect');
+        });
+
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+    });
+
+    test('Test error response of updateCreditorInstitution with intermediary true', async () => {
+        const {store} = renderApp(brokerAndEcDetailsResource_ECAndBroker);
+
+        dispatchAdminSignedInDirectAndFullEcDetails(store);
+
+        const address = screen.getByTestId('address-test') as HTMLInputElement;
+
+        fireEvent.change(address, {target: {value: 'Via Roma 11'}});
+        expect(address.value).toBe('Via Roma 11');
+
+        spyOnUpdateCreditorInstitution.mockRejectedValue(() => {
+            throw new Error('Error in updateCreditorInstitution');
+        });
+
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+    });
+
+    test('Test error response of updateCreditorInstitution with intermediary false', async () => {
+        const {store} = renderApp(brokerAndEcDetailsResource_ECOnly);
+
+        await waitFor(() => dispatchAdminSignedIndirectAndEcDetailsOnly(store));
+
+        const address = screen.getByTestId('address-test') as HTMLInputElement;
+
+        fireEvent.change(address, {target: {value: 'Via Roma 11'}});
+        expect(address.value).toBe('Via Roma 11');
+
+        spyOnUpdateCreditorInstitution.mockRejectedValue(() => {
+            throw new Error('Error in updateCreditorInstitution');
+        });
+
+        const confirmBtn = await screen.findByTestId('continue-button-test');
+        fireEvent.click(confirmBtn);
+    });
 });

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInECForm.test.tsx
@@ -25,7 +25,6 @@ const renderApp = (
 ) => {
     const store = injectedStore ? injectedStore : createStore();
     const history = injectedHistory ? injectedHistory : createMemoryHistory();
-
     const {rerender} = render(
         <Provider store={store}>
             <ThemeProvider theme={theme}>
@@ -40,6 +39,21 @@ const renderApp = (
     );
     return {store, history, rerender};
 };
+
+const reRender = (store: any, history: any, rerender: any, signInData: any, value: boolean) => {
+  rerender( 
+    <Provider store={store}>
+        <ThemeProvider theme={theme}>
+            <Router history={history}>
+                <NodeSignInECForm goBack={jest.fn()} signInData={signInData}
+                                  handleChangeIntermediaryAvailable={jest.fn()}
+                                  intermediaryAvailableValue={value}
+                                  setIntermediaryAvailableValue={jest.fn()}/>
+            </Router>
+        </ThemeProvider>
+    </Provider>
+  );
+}
 
 const setupForm = () => {
     const address = screen.getByTestId('address-test') as HTMLInputElement;
@@ -154,16 +168,7 @@ describe('NodeSignInECForm', () => {
 
         fireEvent.click(intermediaryTrue);
 
-        rerender( <Provider store={store}>
-            <ThemeProvider theme={theme}>
-                <Router history={history}>
-                    <NodeSignInECForm goBack={jest.fn()} signInData={{}}
-                                      handleChangeIntermediaryAvailable={jest.fn()}
-                                      intermediaryAvailableValue={true}
-                                      setIntermediaryAvailableValue={jest.fn()}/>
-                </Router>
-            </ThemeProvider>
-        </Provider>);
+        reRender(store, history, rerender, {}, true);
 
         const confirmBtn = await screen.findByTestId('continue-button-test');
         fireEvent.click(confirmBtn);
@@ -211,16 +216,7 @@ describe('NodeSignInECForm', () => {
 
         fireEvent.click(intermediaryTrue);
 
-        rerender( <Provider store={store}>
-            <ThemeProvider theme={theme}>
-                <Router history={history}>
-                    <NodeSignInECForm goBack={jest.fn()} signInData={brokerAndEcDetailsResource_ECOnly}
-                                      handleChangeIntermediaryAvailable={jest.fn()}
-                                      intermediaryAvailableValue={true}
-                                      setIntermediaryAvailableValue={jest.fn()}/>
-                </Router>
-            </ThemeProvider>
-        </Provider>);
+        reRender(store, history, rerender, brokerAndEcDetailsResource_ECOnly, true);
 
         const confirmBtn = await screen.findByTestId('continue-button-test');
         fireEvent.click(confirmBtn);
@@ -309,16 +305,7 @@ describe('NodeSignInECForm', () => {
 
         expect(intermediaryTrue.checked).toBe(false);
         fireEvent.click(intermediaryTrue);
-        rerender( <Provider store={store}>
-            <ThemeProvider theme={theme}>
-                <Router history={history}>
-                    <NodeSignInECForm goBack={jest.fn()} signInData={brokerAndEcDetailsResource_ECOnly}
-                                      handleChangeIntermediaryAvailable={jest.fn()}
-                                      intermediaryAvailableValue={true}
-                                      setIntermediaryAvailableValue={jest.fn()}/>
-                </Router>
-            </ThemeProvider>
-        </Provider>);
+        reRender(store, history, rerender, brokerAndEcDetailsResource_ECOnly, true);
         expect(intermediaryTrue.checked).toBe(true);
 
         const confirmBtn = await screen.findByTestId('continue-button-test');

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPSPForm.test.tsx
@@ -35,19 +35,41 @@ const renderApp = (
 ) => {
   const store = injectedStore ? injectedStore : createStore();
   const history = injectedHistory ? injectedHistory : createMemoryHistory();
-  render(
+  const {rerender} = render(
     <Provider store={store}>
       <ThemeProvider theme={theme}>
         <MemoryRouter initialEntries={[`/node-signin`]}>
           <Route path="/node-signin">
-            <NodeSignInPSPForm goBack={jest.fn()} signInData={signInData} />
+            <NodeSignInPSPForm goBack={jest.fn()} 
+                               signInData={signInData}
+                               handleChangeIntermediaryAvailable={jest.fn}
+                               intermediaryAvailableValue={false}
+                               setIntermediaryAvailableValue={jest.fn}/>
           </Route>
         </MemoryRouter>
       </ThemeProvider>
     </Provider>
   );
-  return { store, history };
+  return { store, history, rerender };
 };
+
+const reRender = (store: any, rerender: any, signinData: any, value: boolean) => {
+  rerender(
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <MemoryRouter initialEntries={[`/node-signin`]}>
+          <Route path="/node-signin">
+            <NodeSignInPSPForm goBack={jest.fn()} 
+                               signInData={signinData}
+                               handleChangeIntermediaryAvailable={jest.fn}
+                               intermediaryAvailableValue={value}
+                               setIntermediaryAvailableValue={jest.fn}/>
+          </Route>
+        </MemoryRouter>
+      </ThemeProvider>
+    </Provider>
+  );
+}
 
 const setupFormAndSubmit = async (store) => {
   await waitFor(() =>
@@ -129,7 +151,7 @@ describe('NodeSignInPSPForm', () => {
   });
 
   test('Test rendering NodeSignInPSPForm with intermediary true and Sumbit', async () => {
-    const { store } = renderApp({});
+    const { store, rerender } = renderApp({});
 
     await waitFor(() =>
       store.dispatch({
@@ -152,6 +174,8 @@ describe('NodeSignInPSPForm', () => {
       .querySelector('[value=true]') as HTMLInputElement;
 
     fireEvent.click(intermediaryTrue);
+
+    reRender(store, rerender, {}, true);
 
     await waitFor(() => expect(createPSPDirectMocked).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(useSigninDataMocked).toHaveBeenCalled());
@@ -187,7 +211,7 @@ describe('NodeSignInPSPForm', () => {
   });
 
   test('Test rendering NodeSignInPSPForm with intermediary true and Sumbit with createPspBroker api call', async () => {
-    const { store } = renderApp(brokerOrPspDetailsResource_PSPOnly);
+    const { store, rerender } = renderApp(brokerOrPspDetailsResource_PSPOnly);
 
     await waitFor(() =>
       store.dispatch({
@@ -204,12 +228,14 @@ describe('NodeSignInPSPForm', () => {
     );
 
     await setupFormAndSubmit(store);
-
+    
     const intermediaryTrue = screen
       .getByTestId('intermediary-available-test')
       .querySelector('[value=true]') as HTMLInputElement;
 
     fireEvent.click(intermediaryTrue);
+
+    reRender(store, rerender, brokerOrPspDetailsResource_PSPOnly, true);
 
     await waitFor(() => expect(createPspBroker).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(useSigninDataMocked).toHaveBeenCalled());
@@ -276,7 +302,7 @@ test('Test rendering NodeSignInPSPForm in case of updating the form with a psp d
 });
 
 test('Test rendering NodeSignInPSPForm in case of updating the form with a psp indirect', async () => {
-  const { store } = renderApp(brokerOrPspDetailsResource_PSPOnly);
+  const { store, rerender } = renderApp(brokerOrPspDetailsResource_PSPOnly);
 
   await waitFor(() =>
     store.dispatch({
@@ -309,6 +335,7 @@ test('Test rendering NodeSignInPSPForm in case of updating the form with a psp i
 
   expect(intermediaryTrue.checked).toBe(false);
   fireEvent.click(intermediaryTrue);
+  reRender(store, rerender, brokerOrPspDetailsResource_PSPOnly, true);
   expect(intermediaryTrue.checked).toBe(true);
 
   const confirmBtn = await screen.findByTestId('continue-button-test');

--- a/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPage.test.tsx
+++ b/src/pages/dashboard/nodeSignIn/__tests__/NodeSignInPage.test.tsx
@@ -40,6 +40,39 @@ const renderApp = (
   return { store, history };
 };
 
+test('Test rendering modal', async () => {
+  const { store } = renderApp();
+  await waitFor(() => {
+    store.dispatch({
+      type: 'parties/setPartySelected',
+      payload: pspAdminSignedDirect,
+    });
+
+    store.dispatch({
+      type: 'parties/setSigninData',
+      payload: pspDetails,
+    });
+  });
+
+  // testing confirm button
+  const intermediaryTrue = screen
+    .getByTestId('intermediary-available-test')
+    .querySelector('[value=true]') as HTMLInputElement;
+  fireEvent.click(intermediaryTrue);
+  expect(screen.getByTestId('fade-test')).toBeVisible();
+  fireEvent.click(screen.getByTestId('confirm-button-modal-test'));
+  expect(screen.getByTestId('fade-test')).not.toBeVisible();
+
+  // testing cancel button
+  const intermediaryFalse = screen
+    .getByTestId('intermediary-available-test')
+    .querySelector('[value=false]') as HTMLInputElement;
+  fireEvent.click(intermediaryFalse);
+  fireEvent.click(intermediaryTrue);
+  fireEvent.click(screen.getByTestId('cancel-button-modal-test'));
+  expect(screen.getByTestId('fade-test')).not.toBeVisible();
+});
+
 test('Test rendering with psp', async () => {
   const { store } = renderApp();
   await waitFor(() => {
@@ -54,6 +87,14 @@ test('Test rendering with psp', async () => {
     });
   });
   expect(screen.getByText(/Marca da bollo digitale/i)).toBeVisible();
+
+  const intermediaryTrue = screen
+    .getByTestId('intermediary-available-test')
+    .querySelector('[value=true]') as HTMLInputElement;
+  fireEvent.click(intermediaryTrue);
+  expect(screen.getByTestId('fade-test')).toBeVisible();
+  fireEvent.click(screen.getByTestId('confirm-button-modal-test'));
+  expect(screen.getByTestId('fade-test')).not.toBeVisible();
 });
 
 test('Test rendering with ec', async () => {
@@ -65,6 +106,12 @@ test('Test rendering with ec', async () => {
     })
   );
   expect(screen.getAllByText(/Domicilio Fiscale/i).length).toBeGreaterThan(0);
+
+  const intermediaryTrue = screen
+    .getByTestId('intermediary-available-test')
+    .querySelector('[value=true]') as HTMLInputElement;
+  fireEvent.click(intermediaryTrue);
+  expect(screen.getByTestId('fade-test')).toBeVisible();
 });
 
 test('Test rendering with pt', async () => {

--- a/src/pages/dashboard/nodeSignIn/components/CommonRadioGroup.tsx
+++ b/src/pages/dashboard/nodeSignIn/components/CommonRadioGroup.tsx
@@ -5,7 +5,7 @@ import {
 } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import { useTranslation } from 'react-i18next';
-import { useEffect } from 'react';
+import { ChangeEvent, useEffect } from 'react';
 import FormSectionTitle from '../../../../components/Form/FormSectionTitle';
 import { BrokerAndEcDetailsResource } from '../../../../api/generated/portal/BrokerAndEcDetailsResource';
 import { BrokerOrPspDetailsResource } from '../../../../api/generated/portal/BrokerOrPspDetailsResource';
@@ -14,7 +14,7 @@ type Props = {
   labelTrue: string;
   labelFalse: string;
   value: boolean;
-  onChange: () => void;
+  onChange: (event: ChangeEvent<HTMLInputElement> | undefined) => void;
   ecDirect?: BrokerAndEcDetailsResource;
   pspDirect?: BrokerOrPspDetailsResource;
 };


### PR DESCRIPTION
This PR contains the definition of a modal that permits to confirm if a CI/PSP will connect directly or indirectly with Nodo system. The modal contains a message that permits the user to better understand the action that it is executing during the sign-in.

#### List of Changes
 - Added confirmation modal on creditor institution's sign-in form for connection types with Nodo
 - Added confirmation modal on payment service provider's sign-in form for connection types with Nodo
 - Updated unit tests

#### Motivation and Context
These changes are required in order to add a new popup during sign-in operation.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
