### PR TITLE
[PASELC-596] fix: resolved wrong BIC format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@
 
 ## To build a configured workspace execute the following command
 - yarn build
+
+## To execute a coverage check based on unit test execute the following command
+- yarn test:coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagopa-selfcare-frontend",
-  "version": "0.1.0",
+  "version": "0.1.0-1-PASELC-596-fase-di-registrazione-codice-bic-formato-errato",
   "homepage": "ui",
   "private": true,
   "scripts": {

--- a/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
+++ b/src/pages/dashboard/nodeSignIn/NodeSignInPSPForm.tsx
@@ -90,14 +90,14 @@ const NodeSignInPSPForm = ({ goBack, signInData }: Props) => {
       }).filter(([_key, value]) => value)
     );
 
-  const handleChangeNumberOnly = (
+  const handleChangeAlphanumericOnly = (
     e: React.ChangeEvent<any>,
     field: string,
     formik: FormikProps<NodeOnSignInPSP>
   ) => {
-    const regex = /^[0-9\b]+$/;
+    const regex = /^[0-9a-zA-Z\b]+$/;
     if (e.target.value === '' || regex.test(e.target.value)) {
-      formik.setFieldValue(field, e.target.value);
+      formik.setFieldValue(field, e.target.value.toUpperCase());
     }
   };
 
@@ -290,13 +290,13 @@ const NodeSignInPSPForm = ({ goBack, signInData }: Props) => {
                     label={t('nodeSignInPage.form.pspFields.bicCode')}
                     size="small"
                     inputProps={{
-                      maxLength: 5,
-                      inputMode: 'numeric',
-                      pattern: '[0-9]*',
+                      maxLength: 11,
+                      inputMode: 'text',
+                      pattern: '[0-9a-zA-Z]*',
                       'data-testid': 'bicCode-test',
                     }}
                     value={formik.values.bicCode}
-                    onChange={(e) => handleChangeNumberOnly(e, 'bicCode', formik)}
+                    onChange={(e) => handleChangeAlphanumericOnly(e, 'bicCode', formik)}
                     error={formik.touched.bicCode && Boolean(formik.errors.bicCode)}
                     helperText={formik.touched.bicCode && formik.errors.bicCode}
                   />


### PR DESCRIPTION
On PSP's sign-in process, in the related form the BIC code's text box was set in order to only accept 5-digit numerical codes (for example, 12345). This behavior is not correct because in specific situations, like with foreign PSPs, the BIC code can reach 11-character string in alphanumeric structure (for example BTI000IT001).
This fix is made in order to resolve this wrong setting, allowing the insertion of more complex BIC codes.

#### List of Changes
 - Updated text box check, allowing 11-char codes instead of 5-digit codes

#### Motivation and Context
This PR was made in order to resolve the bug described before.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):
![Screenshot 2023-11-23 alle 10 54 31](https://github.com/pagopa/pagopa-selfcare-frontend/assets/117269497/580a8767-3f18-482b-887b-ef298f0df328)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
