### PR TITLE
[PASELC-595] fix: updated total items info

### DIFF
--- a/openApi/portal-api-docs.json
+++ b/openApi/portal-api-docs.json
@@ -8725,6 +8725,10 @@
           "total_pages": {
             "type": "integer",
             "format": "int32"
+          },
+          "total_items": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagopa-selfcare-frontend",
-  "version": "0.3.0",
+  "version": "0.3.0-1-PASELC-595-conteggio-ec-psp-nella-form-di-riepilogo-della-stazione-canale-errato",
   "homepage": "ui",
   "private": true,
   "scripts": {

--- a/src/pages/channels/detail/ChannelDetailPage.tsx
+++ b/src/pages/channels/detail/ChannelDetailPage.tsx
@@ -31,7 +31,7 @@ const ChannelDetailPage = () => {
     Promise.all([getChannelDetail(channelId), getChannelPSPs(channelId, 0)])
       .then(([channelDetailResponse, channelPSPList]) => {
         setChannelDetail(channelDetailResponse);
-        setPSPAssociatedNumber(channelPSPList?.page_info?.items_found ?? 0);
+        setPSPAssociatedNumber(channelPSPList?.page_info?.total_items ?? 0);
       })
       .catch((reason) => {
         addError({

--- a/src/pages/stations/detail/StationDetailPage.tsx
+++ b/src/pages/stations/detail/StationDetailPage.tsx
@@ -31,7 +31,7 @@ const StationDetailPage = () => {
     Promise.all([getStationDetail(stationId), getECListByStationCode(stationId, 0)])
       .then(([stationDetail, ecList]) => {
         setStationDetail(stationDetail);
-        setECAssociatedNumber(ecList?.page_info?.items_found ?? 0);
+        setECAssociatedNumber(ecList?.page_info?.total_items ?? 0);
       })
       .catch((reason) => {
         addError({

--- a/src/services/__mocks__/channelService.ts
+++ b/src/services/__mocks__/channelService.ts
@@ -55,6 +55,7 @@ export const mockedChannels: ChannelsResource = {
     limit: 50,
     items_found: 50,
     total_pages: 8,
+    total_items: 400
   },
 };
 
@@ -218,6 +219,7 @@ export const mockedStationsMerged: WrapperChannelsResource = {
     limit: 10,
     items_found: 5,
     total_pages: 1,
+    total_items: 5
   },
   channels: [
     {
@@ -327,8 +329,9 @@ export const mockedChannelPSPs: ChannelPspListResource = {
   page_info: {
     page: 0,
     limit: 5,
-    items_found: 8,
+    items_found: 5,
     total_pages: 2,
+    total_items: 8
   },
 };
 export const mockedChannelPSPsPage2: ChannelPspListResource = {
@@ -355,8 +358,9 @@ export const mockedChannelPSPsPage2: ChannelPspListResource = {
   page_info: {
     page: 1,
     limit: 5,
-    items_found: 8,
+    items_found: 5,
     total_pages: 2,
+    total_items: 8
   },
 };
 

--- a/src/services/__mocks__/stationService.ts
+++ b/src/services/__mocks__/stationService.ts
@@ -441,7 +441,7 @@ export const mockedStationECs: CreditorInstitutionsResource = {
       segregationCode: '11',
     },
   ],
-  page_info: { page: 0, limit: 10, items_found: 11, total_pages: 2 },
+  page_info: { page: 0, limit: 10, items_found: 10, total_pages: 2, total_items: 11 },
 };
 
 export const mockedStationECsPage2: CreditorInstitutionsResource = {
@@ -453,7 +453,7 @@ export const mockedStationECsPage2: CreditorInstitutionsResource = {
       broadcast: false,
     },
   ],
-  page_info: { page: 1, limit: 10, items_found: 11, total_pages: 2 },
+  page_info: { page: 1, limit: 10, items_found: 10, total_pages: 2, total_items: 11 },
 };
 export const stationWrapperMockedGet = (code: string): WrapperEntitiesOperations => ({
   brokerCode: 'string',


### PR DESCRIPTION
The retrieving of the number of associated channel for PSP and of associated station for EC in BO portal was wrong and the extracted value was the same value of the element that can be included in a paginated `get` operation. With this PR it was added a new field, named `total_items`, that permits to retrieve the correct number of elements filterable by paginated `get`.

#### List of Changes
 - Added new field for actual total items value

#### Motivation and Context
This change is required in order to correctly show the counter values in BO portal

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
