### PR TITLE
[PASELC-622] Error with CI/PSP already registered

### DIFF
--- a/openApi/portal-api-docs.json
+++ b/openApi/portal-api-docs.json
@@ -3,7 +3,7 @@
   "info" : {
     "title" : "pagopa-selfcare-ms-backoffice",
     "description" : "PagoPa backoffice API documentation",
-    "version" : "0.5.2-1-PASELC-623-be-errore-di-validazione-campi-institution"
+    "version" : "0.5.1"
   },
   "servers" : [ {
     "url" : "http://localhost:80",
@@ -7665,7 +7665,6 @@
       },
       "CreditorInstitutionAddressResource" : {
         "title" : "CreditorInstitutionAddressResource",
-        "required" : [ "city", "countryCode", "location", "zipCode" ],
         "type" : "object",
         "properties" : {
           "city" : {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagopa-selfcare-frontend",
-  "version": "0.3.2",
+  "version": "0.3.2-1-PASELC-622-errore-durante-la-creazione-ec-gia-censito",
   "homepage": "ui",
   "private": true,
   "scripts": {


### PR DESCRIPTION
During several tests in UAT and PROD, a bug related to the registration steps was found and caused the institution to be unabled to proceed to use the BackOffice portal.
When the BackOffice Backend executed the logic related to API `utils/ec-brokers/{code}/details`, in some circumstances (i.e. the entities massively imported by SelfCare) the response contains an empty field `address`. This address is correctly set as optional for the Java model validator but was wrongly set as mandatory in the OpenAPI specs. This caused a wrong definition of the OpenAPI documentation that is used by BackOffice frontend in order to generate the models and the API used for communication with backend. So, when the frontend needs to set the sign-in content in local storage, an exception is thrown but a wrong manipulation of the same exception caused the same local content to be an empty object. This empty object caused the logged user (and the related institution) to be always seen as not-registered so when he continue the registration steps, this cannot continue because the institution was already registered.

#### List of Changes
 - Removed mandatory fields constraint wrongly set in OpenAPI specs for `CreditorInstitutionAddressResource`

#### Motivation and Context
This change is required in order to permits some kind of users (i.e. the ones which institution was massively imported and that doesn't have the addresses set yet) to continue to use the BackOffice portal

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
