### PR TITLE
[PASELC-660] fix: removed '-' char for channels' undefined dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagopa-selfcare-backoffice-frontend",
-  "version": "1.13.0",
+  "version": "1.13.0-1-PASELC-660-canali-psp-correggere-date",
   "homepage": "ui",
   "private": true,
   "scripts": {

--- a/src/pages/channels/list/ChannelsTableColumns.tsx
+++ b/src/pages/channels/list/ChannelsTableColumns.tsx
@@ -232,7 +232,7 @@ export function showCreationData(params: GridRenderCellParams) {
                   WebkitBoxOrient: 'vertical' as const,
                 }}
               >
-                {params.row.createdAt ? params.row.createdAt?.toLocaleDateString('en-GB') : '-'}
+                {params.row.createdAt?.toLocaleDateString('en-GB')}
               </Typography>
             </Grid>
           </Grid>
@@ -262,7 +262,7 @@ export function showModifiedData(params: GridRenderCellParams) {
                   WebkitBoxOrient: 'vertical' as const,
                 }}
               >
-                {params.row.modifiedAt ? params.row.modifiedAt?.toLocaleDateString('en-GB') : '-'}
+                {params.row.modifiedAt?.toLocaleDateString('en-GB')}
               </Typography>
             </Grid>
           </Grid>


### PR DESCRIPTION
This PR contains the changes made on the special character set for the undefined channel dates. This char (the character '-') will not be used anymore for describe undefined dates and the empty column will describe this behavior furthermore.

#### List of Changes
 - Removed standard char set in undefined channels dates

#### Motivation and Context
This change remove the not needed set of standard char for channels

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):
![Screenshot 2024-01-09 alle 11 34 36](https://github.com/pagopa/pagopa-selfcare-frontend/assets/117269497/dbf6a357-dce8-4c1f-a65d-b901d66e0655)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
