### PR TITLE
[PASELC-663][PASELC-659] fix: resolved some bugs on frontend found after Go-Live event

### DIFF
--- a/src/pages/channels/detail/components/ChannelDetails.tsx
+++ b/src/pages/channels/detail/components/ChannelDetails.tsx
@@ -31,6 +31,7 @@ const ChannelDetails = ({ channelDetail, channelId, goBack, PSPAssociatedNumber 
   const { t } = useTranslation();
   const operator = isOperator();
   const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [targetValue, setTargetValue] = useState("");
   const hidePassword = 'XXXXXXXXXXXXXX';
   const showOrHidePassword = (password?: string) => {
     if (showPassword) {
@@ -48,7 +49,8 @@ const ChannelDetails = ({ channelDetail, channelId, goBack, PSPAssociatedNumber 
     channelDetail.protocol === ProtocolEnum.HTTPS ? 'https://' : 'http://'
   }${channelDetail.ip}${channelDetail.service}`;
 
-  const targetValue = `${channelDetail.target_host}:${channelDetail.target_port}${channelDetail.target_path}`;
+  const targetPath = (!channelDetail.target_path?.startsWith("/") ? "/" : "").concat(channelDetail.target_path !== undefined ? channelDetail.target_path : "");
+  setTargetValue(`${channelDetail.target_host}:${channelDetail.target_port}${targetPath}`);
 
   return (
     <Grid container justifyContent={'center'}>

--- a/src/pages/channels/detail/components/ChannelDetailsWrap.tsx
+++ b/src/pages/channels/detail/components/ChannelDetailsWrap.tsx
@@ -5,6 +5,7 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 import { TitleBox } from '@pagopa/selfcare-common-frontend';
 import { Link, generatePath } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
 import ROUTES from '../../../../routes';
 import { ChannelDetailsResource } from '../../../../api/generated/portal/ChannelDetailsResource';
 import { WrapperStatusEnum } from '../../../../api/generated/portal/WrapperChannelDetailsResource';
@@ -116,7 +117,7 @@ const ChannelDetailsWrap = ({ channelDetWrap, channelId, goBack, PSPAssociatedNu
                 </Grid>
                 <Grid item xs={6}>
                   <Typography variant="body2" fontWeight={'fontWeightMedium'}>
-                    {`${channelDetWrap.target_host}:${channelDetWrap.target_port}${channelDetWrap.target_path}`}
+                    {`${channelDetWrap.target_host}:${channelDetWrap.target_port}${(!channelDetWrap.target_path?.startsWith("/") ? "/" : "")}${channelDetWrap.target_path}`}
                   </Typography>
                 </Grid>
 

--- a/src/pages/stations/list/StationsTableColumns.tsx
+++ b/src/pages/stations/list/StationsTableColumns.tsx
@@ -163,7 +163,6 @@ export function renderCell(
         paddingTop: '-16px',
         paddingBottom: '-16px',
         marginLeft: '11px',
-        cursor: 'pointer',
         WebkitBoxOrient: 'vertical' as const,
         ...overrideStyle,
       }}
@@ -233,7 +232,7 @@ export function showStationID(params: GridRenderCellParams) {
 export function showStatus(params: GridRenderCellParams) {
   return renderCell(
     params,
-    <Box sx={{ cursor: 'pointer', display: 'flex', justifyContent: 'space-between' }}>
+    <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
       <Chip
         label={
           params.row.wrapperStatus === 'APPROVED'
@@ -245,7 +244,6 @@ export function showStatus(params: GridRenderCellParams) {
         }
         aria-label="Status"
         sx={{
-          cursor: 'pointer',
           fontSize: '10px',
           fontWeight: 'fontWeightRegular',
           color: params.row.wrapperStatus === 'APPROVED' ? '#FFFFFF' : '#17324D',


### PR DESCRIPTION
This PR contains the resolution of multiple bugs found after Go-Live event on BackOffice portal.

#### List of Changes
 - Removed hand-cursor in stations table
 - Added '/' char between target port and service path

#### Motivation and Context
The change are required in order to resolve open bugs found after Go-Live event

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
