### PR TITLE
fix: changed wrong label name on EC-by-station search

### DIFF
--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -577,7 +577,7 @@
   "stationECList": {
     "title": "Gestisci EC",
     "subtitle": "Gestisci e associa nuovi EC.",
-    "searchPlaceholder": "Cerca per nome EC",
+    "searchPlaceholder": "Cerca per nome EC o codice fiscale EC",
     "csvDownload": "Scarica CSV",
     "associateEcButtonLabel": "Associa EC",
     "dissociateEcSuccessMessage": "EC dissociato con successo",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 - Changed label on EC-by-station search filter textbox

#### Motivation and Context
This change permits to resolve a wrong label, not correctly changed in previous PR

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
