### PR TITLE
fix: Broker list error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -201,22 +201,22 @@ const SecuredRoutes = withLogin(
                   </ProtectedRoute>
                 </Route>
                 <Route path={routes.COMMISSION_BUNDLES} exact={true}>
-                  <ProtectedRoute permission="commission-bundles">
+                  <ProtectedRoute permission="commission-bundles-list">
                     <CommissionBundlesPage />
                   </ProtectedRoute>
                 </Route>
                 <Route path={routes.COMMISSION_BUNDLES_DETAIL} exact={true}>
-                  <ProtectedRoute permission="commission-bundles">
+                  <ProtectedRoute permission="commission-bundles-list">
                     <CommissionBundleDetailPage />
                   </ProtectedRoute>
                 </Route>
                 <Route path={routes.COMMISSION_BUNDLES_ADD} exact={true}>
-                  <ProtectedRoute permission="commission-bundles">
+                  <ProtectedRoute permission="commission-bundles-addedit">
                     <AddEditCommissionBundlePage />
                   </ProtectedRoute>
                 </Route>
                 <Route path={routes.COMMISSION_BUNDLES_EDIT} exact={true}>
-                  <ProtectedRoute permission="commission-bundles">
+                  <ProtectedRoute permission="commission-bundles-addedit">
                     <AddEditCommissionBundlePage />
                   </ProtectedRoute>
                 </Route>

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -101,7 +101,7 @@ export default function SideMenu() {
                     )}
 
                     {useFlagValue('commission-bundles')
-                        && hasPermission("commission-bundles") && (
+                        && hasPermission("commission-bundles-list") && (
                             <SidenavItem
                                 title={t('sideMenu.commBundles.title')}
                                 handleClick={() => onExit(() => history.push(ROUTES.COMMISSION_BUNDLES))}

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -13,6 +13,7 @@ export const usePermissions = () => {
   const hasPermission = (permissionName: PermissionName) =>
     userRole ? permissions[permissionName].includes(userRole) : false;
   const isPsp = () => userRole === ROLE.PSP_ADMIN || userRole === ROLE.PSP_DIRECT_ADMIN;
+  const isPspDirect = () => userRole === ROLE.PSP_DIRECT_ADMIN;
   const isEc = () => userRole === ROLE.EC_ADMIN || userRole === ROLE.EC_DIRECT_ADMIN;
-  return { hasPermission, isPsp, isEc };
+  return { hasPermission, isPsp, isEc, isPspDirect };
 };

--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -964,7 +964,8 @@
         "errorMessageChannelIdsDataDesc": "Errore durante la ricezione dei canali",
         "errorMessageCreatingBundle": "Errore durante la creazione del pacchetto commissioni",
         "errorMessageUpdatingBundle": "Errore durante l'aggiornamento del pacchetto commissioni",
-        "errorMessageNoBrokerDelegations": "L’intermediario non ha ancora effettuato la registrazione al Nodo dei Pagamenti"
+        "errorMessageNoBrokerDelegations": "L’intermediario non ha ancora effettuato la registrazione al Nodo dei Pagamenti",
+        "errorMessageNoBroker": "Non sono presenti intermediari"
       }
     }
   },

--- a/src/model/RolePermission.ts
+++ b/src/model/RolePermission.ts
@@ -49,11 +49,15 @@ export const permissions = {
         ROLE.PAGOPA_OPERATOR,
     ],
     iban: [ROLE.EC_DIRECT_ADMIN, ROLE.EC_ADMIN],
-    'commission-bundles': [
+    'commission-bundles-list': [
         ROLE.PSP_DIRECT_ADMIN,
         ROLE.PSP_ADMIN,
         ROLE.EC_ADMIN,
         ROLE.EC_DIRECT_ADMIN
+    ],
+    'commission-bundles-addedit': [
+        ROLE.PSP_DIRECT_ADMIN,
+        ROLE.PSP_ADMIN
     ],
     'operation-table-read-write': [
         ROLE.EC_DIRECT_ADMIN,

--- a/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
+++ b/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
@@ -245,6 +245,15 @@ describe('<AddEditCommissionBundleForm />', () => {
       expect(input.channelList.disabled).toBe(false);
     });
 
+    fireEvent.change(document.activeElement as Element, {
+      target: { value: '' },
+    });
+    fireEvent.keyDown(document.activeElement as Element, { key: 'ArrowDown' });
+    fireEvent.keyDown(document.activeElement as Element, { key: 'Enter' });
+    await waitFor(() => {
+      expect(input.channelList.disabled).toBe(true);
+    });
+
     // Change channel id
     fireEvent.mouseDown(input.channelList);
     fireEvent.select(input.channelList, { target: { value: mockedChannelsIdList[0] } });
@@ -423,6 +432,35 @@ describe('<AddEditCommissionBundleForm />', () => {
       expect(spyOnGetInstitutionService).toHaveBeenCalled();
       expect(spyOnErrorHook).toHaveBeenCalled();
       expect(spyOnGetChannelService).not.toHaveBeenCalled();
+    });
+  });
+
+  test('Test fetch getChannels empty list', async () => {
+    spyOnGetChannelService.mockReturnValue([]);
+    const injectStore = createStore();
+    await waitFor(() =>
+      injectStore.dispatch(partiesActions.setPartySelected(pspOperatorSignedDirect))
+    );
+    componentRender(FormAction.Edit, mockedBundleRequest, injectStore);
+
+    await waitFor(() => {
+      expect(spyOnGetChannelService).toHaveBeenCalled();
+      expect(spyOnErrorHook).toHaveBeenCalled();
+    });
+  });
+
+  test('Test fetch getChannels throw error', async () => {
+    const mockError = new Error('API error message getChannels');
+    spyOnGetChannelService.mockRejectedValue(mockError);
+    const injectStore = createStore();
+    await waitFor(() =>
+      injectStore.dispatch(partiesActions.setPartySelected(pspOperatorSignedDirect))
+    );
+    componentRender(FormAction.Edit, mockedBundleRequest, injectStore);
+
+    await waitFor(() => {
+      expect(spyOnErrorHook).toHaveBeenCalled();
+      expect(spyOnGetChannelService).toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
+++ b/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
@@ -424,7 +424,7 @@ describe('<AddEditCommissionBundleForm />', () => {
   });
 
   test('Test fetch getBrokerDelegation empty list', async () => {
-    spyOnGetInstitutionService.mockReturnValue([]);
+    spyOnGetInstitutionService.mockReturnValue(new Promise(resolve => resolve([])));
 
     componentRender(FormAction.Create);
 
@@ -436,8 +436,8 @@ describe('<AddEditCommissionBundleForm />', () => {
   });
 
   test('Test fetch getChannels empty list', async () => {
-    spyOnGetChannelService.mockReturnValue([]);
-    const injectStore = createStore();
+    spyOnGetChannelService.mockReturnValue(new Promise(resolve => resolve([])));
+    const injectStore = createStore(); 
     await waitFor(() =>
       injectStore.dispatch(partiesActions.setPartySelected(pspOperatorSignedDirect))
     );

--- a/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
+++ b/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
@@ -132,7 +132,7 @@ describe('<AddEditCommissionBundleForm />', () => {
   test('Test AddEditCommissionBundleForm with all input change in CREATE', async () => {
     const injectStore = createStore();
     await waitFor(() => injectStore.dispatch(partiesActions.setPartySelected(pspOperatorSignedDirect)));
-    const { ...input } = componentRender(FormAction.Create, injectStore);
+    const { ...input } = componentRender(FormAction.Create, undefined, injectStore);
     await waitFor(() => {
       expect(spyOnGetPaymentTypes).toHaveBeenCalled();
       expect(spyOnGetTouchpoint).toHaveBeenCalled();
@@ -267,8 +267,9 @@ describe('<AddEditCommissionBundleForm />', () => {
   });
 
   test('Test AddEditCommissionBundleForm with all input change in EDIT', async () => {
-    const { ...input } = componentRender(FormAction.Edit, mockedBundleRequest);
-    await waitFor(() => store.dispatch(partiesActions.setPartySelected(pspOperatorSignedDirect)));
+    const injectStore = createStore();
+    await waitFor(() => injectStore.dispatch(partiesActions.setPartySelected(pspOperatorSignedDirect)));
+    const { ...input } = componentRender(FormAction.Edit, mockedBundleRequest, injectStore);
     await waitFor(() => {
       expect(spyOnGetPaymentTypes).toHaveBeenCalled();
       expect(spyOnGetTouchpoint).toHaveBeenCalled();

--- a/src/pages/commisionalBundles/addEditCommissionBundle/components/AddEditCommissionBundleForm.tsx
+++ b/src/pages/commisionalBundles/addEditCommissionBundle/components/AddEditCommissionBundleForm.tsx
@@ -134,7 +134,7 @@ const AddEditCommissionBundleForm = ({ isEdit, formik, idBrokerPsp }: Props) => 
         }
         let listBroker = brokerDelegation ?? [];
         if (isPspDirect()) {
-          listBroker = addCurrentPSP(brokerDelegation, selectedParty as Party);
+          listBroker = addCurrentPSP(listBroker, selectedParty as Party);
         }
         if (listBroker.length > 0) {
           setBrokerDelegationList(listBroker);

--- a/src/services/__mocks__/institutionsService.ts
+++ b/src/services/__mocks__/institutionsService.ts
@@ -46,24 +46,28 @@ export const mockedDelegatedPSP: Array<Delegation> = [
     broker_name: 'PSP1',
   },
   {
-    broker_id: 'fce5332f-56a4-45b8-8fdc-7667ccdfca5e',
-    broker_name: 'Regione Toscana',
-    id: '2e76eb7f-2f55-4ec3-8f41-1743f827f7db',
-    institution_id: 'dccdade9-4ce4-444b-8b4d-ef50be064847',
+    broker_id: 'fce5332f-56a4-45b8-8fdc-7667ccdfca5e2',
+    broker_name: 'PSP2',
+    id: '2e76eb7f-2f55-4ec3-8f41-1743f827f7db2',
+    institution_id: 'dccdade9-4ce4-444b-8b4d-ef50be064842',
     institution_name:
       "Azienda Pubblica di Servizi alla Persona Montedomini - Sant'Ambrogio - Fuligno - Bigallo",
     institution_type: 'PA',
     product_id: 'prod-pagopa',
-    tax_code: '80001110487',
+    tax_code: '800011104872',
     type: 'PT',
   },
   {
-    institution_id: '0000002',
-    broker_name: 'PSP2',
-  },
-  {
-    institution_id: '0000003',
+    broker_id: 'fce5332f-56a4-45b8-8fdc-7667ccdfca5e3',
     broker_name: 'PSP3',
+    id: '2e76eb7f-2f55-4ec3-8f41-1743f827f7db3',
+    institution_id: 'dccdade9-4ce4-444b-8b4d-ef50be0648473',
+    institution_name:
+      "Azienda Pubblica di Servizi alla Persona Montedomini - Sant'Ambrogio - Fuligno - Bigallo",
+    institution_type: 'PA',
+    product_id: 'prod-pagopa',
+    tax_code: '800011104873',
+    type: 'PT',
   },
   {
     institution_id: '0000004',
@@ -72,6 +76,10 @@ export const mockedDelegatedPSP: Array<Delegation> = [
   {
     institution_id: '0000005',
     broker_name: 'PSP5',
+  },
+  {
+    institution_id: '0000006',
+    broker_name: 'PSP65',
   },
   {
     institution_id: '0000006',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Changed broker list error message
- Added error message to channel API when retrieved list is empty
- Updated pages' permissions

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Add/edit commission bundle page was displaying the wrong error message when the broker list was empty

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
