### PR TITLE
fix: Fixed getChannels from broker tax code

### DIFF
--- a/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
+++ b/src/pages/commisionalBundles/__tests__/addEditCommissionBundles/AddEditCommissionBundleForm.test.tsx
@@ -51,7 +51,7 @@ const TestAddEditCommissionBundleForm = ({
             <AddEditCommissionBundleForm
               formik={formik}
               isEdit={formAction === FormAction.Edit}
-              idBrokerPsp={'idBrokerPsp'}
+              idBrokerPsp={initialValues?.idBrokerPsp}
             />
           </ThemeProvider>
         </Route>

--- a/src/pages/commisionalBundles/addEditCommissionBundle/AddEditCommissionBundlePage.tsx
+++ b/src/pages/commisionalBundles/addEditCommissionBundle/AddEditCommissionBundlePage.tsx
@@ -157,13 +157,14 @@ const AddEditCommissionBundlePage = () => {
   const submit = async (body: BundleRequest) => {
     setLoadingCreating(true);
     const pspTaxCode = selectedParty?.fiscalCode ?? '';
-
+    const formattedBundleBody = {
+      ...body,
+      touchpoint: body.touchpoint !== 'ANY' ? body.touchpoint : undefined,
+      paymentType: body.paymentType !== 'ANY' ? body.paymentType : undefined,
+    };
     const promise = isEdit
-      ? updatePSPBundle(pspTaxCode, bundleId, {...body,
-            touchpoint: body.touchpoint !== 'ANY' ? body.touchpoint : undefined,
-            paymentType: body.paymentType !== 'ANY' ? body.paymentType : undefined,
-      })
-      : createBundle(pspTaxCode, body);
+      ? updatePSPBundle(pspTaxCode, bundleId, formattedBundleBody)
+      : createBundle(pspTaxCode, formattedBundleBody);
 
     promise
       .then((_) => {
@@ -260,7 +261,11 @@ const AddEditCommissionBundlePage = () => {
           style={{ display: activeStep !== 0 ? 'none' : undefined }}
           data-testid="bundle-form-div"
         >
-          <AddEditCommissionBundleForm formik={formik} isEdit={isEdit} idBrokerPsp={isEdit ? bundleDetails?.idBrokerPsp : undefined}/>
+          <AddEditCommissionBundleForm
+            formik={formik}
+            isEdit={isEdit}
+            idBrokerPsp={isEdit ? bundleDetails?.idBrokerPsp : undefined}
+          />
         </div>
         <div
           style={{ display: activeStep !== 1 ? 'none' : undefined }}
@@ -269,7 +274,9 @@ const AddEditCommissionBundlePage = () => {
           <AddEditCommissionBundleTaxonomies
             formik={formik}
             bundleTaxonomies={
-              isEdit && bundleDetails?.transferCategoryList && bundleDetails.transferCategoryList.length > 0
+              isEdit &&
+              bundleDetails?.transferCategoryList &&
+              bundleDetails.transferCategoryList.length > 0
                 ? [...bundleDetails.transferCategoryList]
                 : []
             }

--- a/src/pages/commisionalBundles/addEditCommissionBundle/components/AddEditCommissionBundleForm.tsx
+++ b/src/pages/commisionalBundles/addEditCommissionBundle/components/AddEditCommissionBundleForm.tsx
@@ -185,6 +185,7 @@ const AddEditCommissionBundleForm = ({ isEdit, formik, idBrokerPsp }: Props) => 
   function handleBrokerCodesSelection(
     value: string | null | undefined
   ) {
+    formik.setFieldValue('idChannel', '');
     if (value === null || value === undefined) {
       formik.setFieldValue('idBrokerPsp', '');
       setChannelsId([]);

--- a/src/pages/commisionalBundles/addEditCommissionBundle/components/AddEditCommissionBundleForm.tsx
+++ b/src/pages/commisionalBundles/addEditCommissionBundle/components/AddEditCommissionBundleForm.tsx
@@ -139,10 +139,12 @@ const AddEditCommissionBundleForm = ({ isEdit, formik, idBrokerPsp }: Props) => 
         if (listBroker.length > 0) {
           setBrokerDelegationList(listBroker);
           if (isEdit && idBrokerPsp) {
-            getChannelsByBrokerCode(
-              brokerDelegation?.find((el) => el.institution_name === idBrokerPsp)
-                ?.broker_tax_code ?? ''
-            );
+            const brokerTaxCode = brokerDelegation?.find(
+              (el) => el.institution_name === idBrokerPsp
+            )?.tax_code;
+            if (brokerTaxCode) {
+              getChannelsByBrokerCode(brokerTaxCode);
+            }
           }
         } else {
           addError({
@@ -181,17 +183,19 @@ const AddEditCommissionBundleForm = ({ isEdit, formik, idBrokerPsp }: Props) => 
   const shouldDisableDate = (date: Date) => date < new Date();
 
   function handleBrokerCodesSelection(
-    value: string | null | undefined,
-    formik: FormikProps<BundleRequest>
+    value: string | null | undefined
   ) {
     if (value === null || value === undefined) {
       formik.setFieldValue('idBrokerPsp', '');
       setChannelsId([]);
     } else {
       formik.handleChange('idBrokerPsp')(value);
-      getChannelsByBrokerCode(
-        brokerDelegationList?.find((el) => el.institution_name === value)?.broker_tax_code ?? ''
-      );
+      const brokerTaxCode = brokerDelegationList?.find(
+        (el) => el.institution_name === value
+      )?.tax_code;
+      if (brokerTaxCode) {
+        getChannelsByBrokerCode(brokerTaxCode);
+      }
     }
   }
 
@@ -484,8 +488,8 @@ const AddEditCommissionBundleForm = ({ isEdit, formik, idBrokerPsp }: Props) => 
                     ?.sort((a, b) => a.localeCompare(b))}
                   disabled={!(brokerDelegationList && brokerDelegationList.length > 0)}
                   value={formik.values.idBrokerPsp}
-                  onChange={(_event, value) => {
-                    handleBrokerCodesSelection(value, formik);
+                  onChange={(_, value) => {
+                    handleBrokerCodesSelection(value);
                   }}
                   fullWidth
                   renderInput={(params) => (

--- a/src/services/__mocks__/bundleService.ts
+++ b/src/services/__mocks__/bundleService.ts
@@ -138,7 +138,7 @@ export const mockedBundleRequest: BundleRequest = {
   minPaymentAmount: 40,
   maxPaymentAmount: 150.1,
   paymentType: 'Bonifico - SEPA',
-  touchpoint: 'Tutti',
+  touchpoint: 'ANY',
   transferCategoryList: mockedTaxonomyList.map(el => el.specific_built_in_data),
   type: TypeEnum.GLOBAL,
   validityDateFrom: new Date('2024-02-17'),

--- a/src/services/__mocks__/institutionsService.ts
+++ b/src/services/__mocks__/institutionsService.ts
@@ -44,6 +44,7 @@ export const mockedDelegatedPSP: Array<Delegation> = [
     broker_id: '12345',
     institution_id: '0000001',
     broker_name: 'PSP1',
+    tax_code: '800011104871'
   },
   {
     broker_id: 'fce5332f-56a4-45b8-8fdc-7667ccdfca5e2',
@@ -72,18 +73,22 @@ export const mockedDelegatedPSP: Array<Delegation> = [
   {
     institution_id: '0000004',
     broker_name: 'PSP4',
+    tax_code: '800011104874',
   },
   {
     institution_id: '0000005',
     broker_name: 'PSP5',
-  },
-  {
-    institution_id: '0000006',
-    broker_name: 'PSP65',
+    tax_code: '800011104875',
   },
   {
     institution_id: '0000006',
     broker_name: 'PSP6',
+    tax_code: '800011104876',
+  },
+  {
+    institution_id: '0000007',
+    broker_name: 'PSP76',
+    tax_code: '8000111048747',
   },
 ];
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Changed the property from which the broker tax code is retrieved

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Broker code wasn't correctly passed to the API getChannels so it was returning all channels (instead of filtering by broker tax code) 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
