### PR TITLE
[VAS-1022] fix: Improve user experience and solve security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagopa-selfcare-backoffice-frontend",
-  "version": "1.20.25",
+  "version": "1.20.26",
   "homepage": "ui",
   "private": true,
   "scripts": {

--- a/src/pages/commisionalBundles/CommissionBundlesPage.tsx
+++ b/src/pages/commisionalBundles/CommissionBundlesPage.tsx
@@ -4,6 +4,9 @@ import { TitleBox } from '@pagopa/selfcare-common-frontend';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
+import { BundleResource, TypeEnum } from '../../api/generated/portal/BundleResource';
+import { bundleDetailsSelectors } from '../../redux/slices/bundleDetailsSlice';
+import { useAppSelector } from '../../redux/hooks';
 import { useFlagValue } from '../../hooks/useFeatureFlags';
 import SideMenuLayout from '../../components/SideMenu/SideMenuLayout';
 import CommissionBundlesTable from './list/CommissionBundlesTable';
@@ -35,12 +38,25 @@ const CustomTabPanel = (props: Props) => {
   );
 };
 
+function getTabValue(bundle: BundleResource) {
+  if (bundle?.type === TypeEnum.PRIVATE) {
+    return 0;
+  } else if (bundle?.type === TypeEnum.PUBLIC) {
+    return 1;
+  }
+
+  return 2;
+}
+
 const CommissionBundlesPage = () => {
   const { t } = useTranslation();
   const history = useHistory();
   const isPrivateEnabled = useFlagValue('commission-bundles-private');
   const isPublicEnabled = useFlagValue('commission-bundles-public');
-  const [value, setValue] = useState(2);
+
+  const commissionBundleDetail: BundleResource =
+    useAppSelector(bundleDetailsSelectors.selectBundleDetails) ?? {};
+  const [tabValue, setTabValue] = useState(getTabValue(commissionBundleDetail));
   const [bundleNameInput, setBundleNameInput] = useState<string>('');
 
   useEffect(() => {
@@ -60,7 +76,7 @@ const CommissionBundlesPage = () => {
   });
 
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
-    setValue(newValue);
+    setTabValue(newValue);
   };
 
   return (
@@ -83,7 +99,7 @@ const CommissionBundlesPage = () => {
       />
       <Box sx={{ borderColor: 'divider', width: '100%', mt: 3 }}>
         <Tabs
-          value={value}
+          value={tabValue}
           onChange={handleChange}
           sx={{ width: '100%' }}
           centered
@@ -108,19 +124,19 @@ const CommissionBundlesPage = () => {
           />
         </Tabs>
       </Box>
-      <CustomTabPanel valueTab={value} index={0}>
+      <CustomTabPanel valueTab={tabValue} index={0}>
         <CommissionBundlesTable
           bundleType={'commissionBundlesPage.privateBundles'}
           bundleNameFilter={bundleNameInput}
         />
       </CustomTabPanel>
-      <CustomTabPanel valueTab={value} index={1}>
+      <CustomTabPanel valueTab={tabValue} index={1}>
         <CommissionBundlesTable
           bundleType={'commissionBundlesPage.publicBundles'}
           bundleNameFilter={bundleNameInput}
         />
       </CustomTabPanel>
-      <CustomTabPanel valueTab={value} index={2}>
+      <CustomTabPanel valueTab={tabValue} index={2}>
         <CommissionBundlesTable
           bundleType={'commissionBundlesPage.globalBundles'}
           bundleNameFilter={bundleNameInput}

--- a/src/pages/commisionalBundles/__tests__/CommissionBundlesPage.test.tsx
+++ b/src/pages/commisionalBundles/__tests__/CommissionBundlesPage.test.tsx
@@ -1,42 +1,80 @@
 import { ThemeProvider } from '@mui/system';
 import { theme } from '@pagopa/mui-italia';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { store } from '../../../redux/store';
 import { Provider } from 'react-redux';
 import React from 'react';
 import CommissionBundlesPage from '../CommissionBundlesPage';
-import * as useFeatureFlags from "../../../hooks/useFeatureFlags";
+import * as useFeatureFlags from '../../../hooks/useFeatureFlags';
+import { BundleResource } from '../../../api/generated/portal/BundleResource';
+import { bundleDetailsActions } from '../../../redux/slices/bundleDetailsSlice';
+import { useAppDispatch } from '../../../redux/hooks';
+import {
+  mockedCommissionBundlePspDetailGlobal,
+  mockedCommissionBundlePspDetailPrivate,
+  mockedCommissionBundlePspDetailPublic,
+} from '../../../services/__mocks__/bundleService';
 
 let spyOnUseFlagValue: jest.SpyInstance<boolean, string[]>;
 
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
-  spyOnUseFlagValue = jest.spyOn(useFeatureFlags, "useFlagValue");
+  spyOnUseFlagValue = jest.spyOn(useFeatureFlags, 'useFlagValue');
 });
 
 afterEach(cleanup);
 
+const ComponentRender = ({ bundle }: { bundle: BundleResource }) => {
+  const dispatch = useAppDispatch();
+  dispatch(bundleDetailsActions.setBundleDetailsState(bundle));
+
+  return (
+    <MemoryRouter initialEntries={[`/comm-bundles`]}>
+      <Route path="/comm-bundles">
+        <ThemeProvider theme={theme}>
+          <CommissionBundlesPage />
+        </ThemeProvider>
+      </Route>
+    </MemoryRouter>
+  );
+};
+
 describe('<CommisionalBundlesPage />', () => {
-  test('render component CommisionalBundlesPage all package types', () => {
+  test('render component CommisionalBundlesPage all package types', async () => {
     spyOnUseFlagValue.mockReturnValue(true);
 
     render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[`/comm-bundles`]}>
-          <Route path="/comm-bundles">
-            <ThemeProvider theme={theme}>
-              <CommissionBundlesPage />
-            </ThemeProvider>
-          </Route>
-        </MemoryRouter>
+        <ComponentRender bundle={mockedCommissionBundlePspDetailGlobal} />
       </Provider>
     );
 
-    expect(screen.getByTestId("tab-private")).not.toBeDisabled();
-    expect(screen.getByTestId("tab-public")).not.toBeDisabled();
-    expect(screen.getByTestId("tab-global")).not.toBeDisabled();
+    expect(screen.getByTestId('tab-private')).not.toBeDisabled();
+    expect(screen.getByTestId('tab-public')).not.toBeDisabled();
+    expect(screen.getByTestId('tab-global')).not.toBeDisabled();
+
+    expect(screen.queryByTestId('table-PRIVATE')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('table-PUBLIC')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('table-GLOBAL')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('tab-public'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('table-PRIVATE')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('table-PUBLIC')).toBeInTheDocument();
+      expect(screen.queryByTestId('table-GLOBAL')).not.toBeInTheDocument();
+    })
+
+    fireEvent.click(screen.getByTestId('tab-private'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('table-PRIVATE')).toBeInTheDocument();
+      expect(screen.queryByTestId('table-PUBLIC')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('table-GLOBAL')).not.toBeInTheDocument();
+    })
+
   });
 
   test('render component CommisionalBundlesPage only global', () => {
@@ -44,58 +82,52 @@ describe('<CommisionalBundlesPage />', () => {
 
     render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[`/comm-bundles`]}>
-          <Route path="/comm-bundles">
-            <ThemeProvider theme={theme}>
-              <CommissionBundlesPage />
-            </ThemeProvider>
-          </Route>
-        </MemoryRouter>
+        <ComponentRender bundle={mockedCommissionBundlePspDetailGlobal} />
       </Provider>
     );
 
-    expect(screen.getByTestId("tab-private")).toBeDisabled();
-    expect(screen.getByTestId("tab-public")).toBeDisabled();
-    expect(screen.getByTestId("tab-global")).not.toBeDisabled();
+    expect(screen.getByTestId('tab-private')).toBeDisabled();
+    expect(screen.getByTestId('tab-public')).toBeDisabled();
+    expect(screen.getByTestId('tab-global')).not.toBeDisabled();
+
+    expect(screen.queryByTestId('table-PRIVATE')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('table-PUBLIC')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('table-GLOBAL')).toBeInTheDocument();
   });
 
   test('render component CommisionalBundlesPage only private & global', () => {
-    spyOnUseFlagValue.mockImplementation((arg) => arg === "commission-bundles-private") ;
+    spyOnUseFlagValue.mockImplementation((arg) => arg === 'commission-bundles-private');
 
     render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[`/comm-bundles`]}>
-          <Route path="/comm-bundles">
-            <ThemeProvider theme={theme}>
-              <CommissionBundlesPage />
-            </ThemeProvider>
-          </Route>
-        </MemoryRouter>
+        <ComponentRender bundle={mockedCommissionBundlePspDetailPrivate} />
       </Provider>
     );
 
-    expect(screen.getByTestId("tab-private")).not.toBeDisabled();
-    expect(screen.getByTestId("tab-public")).toBeDisabled();
-    expect(screen.getByTestId("tab-global")).not.toBeDisabled();
+    expect(screen.getByTestId('tab-private')).not.toBeDisabled();
+    expect(screen.getByTestId('tab-public')).toBeDisabled();
+    expect(screen.getByTestId('tab-global')).not.toBeDisabled();
+
+    expect(screen.queryByTestId('table-PRIVATE')).toBeInTheDocument();
+    expect(screen.queryByTestId('table-PUBLIC')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('table-GLOBAL')).not.toBeInTheDocument();
   });
 
   test('render component CommisionalBundlesPage only public & global', () => {
-    spyOnUseFlagValue.mockImplementation((arg) => arg === "commission-bundles-public") ;
+    spyOnUseFlagValue.mockImplementation((arg) => arg === 'commission-bundles-public');
 
     render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[`/comm-bundles`]}>
-          <Route path="/comm-bundles">
-            <ThemeProvider theme={theme}>
-              <CommissionBundlesPage />
-            </ThemeProvider>
-          </Route>
-        </MemoryRouter>
+        <ComponentRender bundle={mockedCommissionBundlePspDetailPublic} />
       </Provider>
     );
 
-    expect(screen.getByTestId("tab-private")).toBeDisabled();
-    expect(screen.getByTestId("tab-public")).not.toBeDisabled();
-    expect(screen.getByTestId("tab-global")).not.toBeDisabled();
+    expect(screen.getByTestId('tab-private')).toBeDisabled();
+    expect(screen.getByTestId('tab-public')).not.toBeDisabled();
+    expect(screen.getByTestId('tab-global')).not.toBeDisabled();
+
+    expect(screen.queryByTestId('table-PRIVATE')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('table-PUBLIC')).toBeInTheDocument();
+    expect(screen.queryByTestId('table-GLOBAL')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/commisionalBundles/addEditCommissionBundle/AddEditCommissionBundlePage.tsx
+++ b/src/pages/commisionalBundles/addEditCommissionBundle/AddEditCommissionBundlePage.tsx
@@ -150,11 +150,12 @@ const AddEditCommissionBundlePage = () => {
   const selectedParty = useAppSelector(partiesSelectors.selectPartySelected);
   const setLoading = useLoading(LOADING_TASK_COMMISSION_BUNDLE_DETAIL);
   const setLoadingCreating = useLoading(LOADING_TASK_CREATING_COMMISSION_BUNDLE);
-  const { bundleId, actionId } = useParams<{ bundleId: string; actionId: string }>();
+  const { actionId } = useParams<{ actionId: string }>();
   const [activeStep, setActiveStep] = useState<number>(0);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const isEdit = actionId === FormAction.Edit;
   const bundleDetails = useAppSelector(bundleDetailsSelectors.selectBundleDetails);
+  const bundleId = bundleDetails?.idBundle ?? "";
 
   const formik = useFormik<Partial<BundleRequest>>({
     initialValues: toNewFormData(selectedParty, {}),

--- a/src/pages/commisionalBundles/addEditCommissionBundle/AddEditCommissionBundlePage.tsx
+++ b/src/pages/commisionalBundles/addEditCommissionBundle/AddEditCommissionBundlePage.tsx
@@ -21,7 +21,7 @@ import { useEffect, useState } from 'react';
 import GenericModal from '../../../components/Form/GenericModal';
 import { Party } from '../../../model/Party';
 import ROUTES from '../../../routes';
-import { useAppSelector } from '../../../redux/hooks';
+import { useAppSelector, useAppSelectorWithRedirect } from '../../../redux/hooks';
 import { partiesSelectors } from '../../../redux/slices/partiesSlice';
 import { FormAction } from '../../../model/CommissionBundle';
 import { bundleDetailsSelectors } from '../../../redux/slices/bundleDetailsSlice';
@@ -153,9 +153,9 @@ const AddEditCommissionBundlePage = () => {
   const { actionId } = useParams<{ actionId: string }>();
   const [activeStep, setActiveStep] = useState<number>(0);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
-  const isEdit = actionId === FormAction.Edit;
-  const bundleDetails = useAppSelector(bundleDetailsSelectors.selectBundleDetails);
-  const bundleId = bundleDetails?.idBundle ?? "";
+  const isEdit: boolean = actionId === FormAction.Edit;
+  const bundleDetails: BundleResource = useAppSelectorWithRedirect(bundleDetailsSelectors.selectBundleDetails, isEdit ? ROUTES.COMMISSION_BUNDLES : undefined) ?? {};
+  const bundleId: string = bundleDetails?.idBundle ?? "";
 
   const formik = useFormik<Partial<BundleRequest>>({
     initialValues: toNewFormData(selectedParty, {}),

--- a/src/pages/commisionalBundles/addEditCommissionBundle/__tests__/AddEditCommissionBundlePage.test.tsx
+++ b/src/pages/commisionalBundles/addEditCommissionBundle/__tests__/AddEditCommissionBundlePage.test.tsx
@@ -139,7 +139,7 @@ describe('<AddEditCommissionBundlePage />', () => {
     requestBundle.validityDateFrom = removeDateZoneInfo(requestBundle.validityDateFrom);
     requestBundle.validityDateTo = removeDateZoneInfo(requestBundle.validityDateTo);
     await waitFor(() => {
-      expect(spyOnUpdateBundle).toHaveBeenCalledWith('', name, requestBundle);
+      expect(spyOnUpdateBundle).toHaveBeenCalledWith('', mockedCommissionBundlePspDetailGlobal.idBundle, requestBundle);
     });
   });
 
@@ -376,7 +376,7 @@ describe('<AddEditCommissionBundlePage />', () => {
     requestBundle.validityDateFrom = removeDateZoneInfo(requestBundle.validityDateFrom);
     requestBundle.validityDateTo = removeDateZoneInfo(requestBundle.validityDateTo);
     await waitFor(() => {
-      expect(spyOnUpdateBundle).toHaveBeenCalledWith('', name, requestBundle);
+      expect(spyOnUpdateBundle).toHaveBeenCalledWith('', mockedCommissionBundlePspDetailGlobal.idBundle, requestBundle);
     });
   });
 });

--- a/src/pages/commisionalBundles/detail/CommissionBundleDetailActivationPage.tsx
+++ b/src/pages/commisionalBundles/detail/CommissionBundleDetailActivationPage.tsx
@@ -9,7 +9,7 @@ import { NumericFormat } from 'react-number-format';
 import EuroIcon from '@mui/icons-material/Euro';
 import ROUTES from '../../../routes';
 import GenericModal from '../../../components/Form/GenericModal';
-import { useAppSelector } from '../../../redux/hooks';
+import { useAppSelector, useAppSelectorWithRedirect} from '../../../redux/hooks';
 import { bundleDetailsSelectors } from '../../../redux/slices/bundleDetailsSlice';
 import { LOADING_TASK_COMMISSION_BUNDLE_ACTIVATION } from '../../../utils/constants';
 import { createCIBundleRequest } from '../../../services/bundleService';
@@ -42,7 +42,7 @@ export default function CommissionBundleDetailActivationPage() {
   const addError = useErrorDispatcher();
 
   const selectedParty = useAppSelector(partiesSelectors.selectPartySelected);
-  const bundleDetails = useAppSelector(bundleDetailsSelectors.selectBundleDetails);
+  const bundleDetails: BundleResource = useAppSelectorWithRedirect(bundleDetailsSelectors.selectBundleDetails, ROUTES.COMMISSION_BUNDLES) ?? {};
 
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
   const [bundleRequest, setBundleRequest] = useState<Partial<PublicBundleRequest>>(

--- a/src/pages/commisionalBundles/detail/CommissionBundleDetailPage.tsx
+++ b/src/pages/commisionalBundles/detail/CommissionBundleDetailPage.tsx
@@ -12,7 +12,7 @@ import {
   CiBundleStatusEnum,
   TypeEnum,
 } from '../../../api/generated/portal/BundleResource';
-import { useAppSelector } from '../../../redux/hooks';
+import { useAppSelector, useAppSelectorWithRedirect } from '../../../redux/hooks';
 import { LOADING_TASK_COMMISSION_BUNDLE_DETAIL } from '../../../utils/constants';
 import { partiesSelectors } from '../../../redux/slices/partiesSlice';
 import { BundleDetailsActionTypes, FormAction } from '../../../model/CommissionBundle';
@@ -162,8 +162,10 @@ const CommissionBundleDetailPage = () => {
   const selectedParty: Party | undefined = useAppSelector(partiesSelectors.selectPartySelected);
   const addError = useErrorDispatcher();
 
-  const commissionBundleDetail: BundleResource =
-    useAppSelector(bundleDetailsSelectors.selectBundleDetails) ?? {};
+  const commissionBundleDetail: BundleResource = useAppSelectorWithRedirect(
+    bundleDetailsSelectors.selectBundleDetails,
+    ROUTES.COMMISSION_BUNDLES
+  );
   const bundleId = commissionBundleDetail.idBundle ?? '';
   const [showConfirmModal, setShowConfirmModal] = useState<BundleDetailsActionTypes | null>(null);
 

--- a/src/pages/commisionalBundles/detail/CommissionBundleDetailPage.tsx
+++ b/src/pages/commisionalBundles/detail/CommissionBundleDetailPage.tsx
@@ -1,11 +1,4 @@
-import {
-  Alert,
-  Breadcrumbs,
-  Button,
-  Grid,
-  Stack,
-  Typography,
-} from '@mui/material';
+import { Alert, Breadcrumbs, Button, Grid, Stack, Typography } from '@mui/material';
 import { TitleBox, useErrorDispatcher, useLoading } from '@pagopa/selfcare-common-frontend';
 import { generatePath, Link, useHistory, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -43,7 +36,7 @@ function RenderAlert({ bundleDetail }: { bundleDetail: BundleResource }) {
 
   if (bundleDetail?.ciBundleStatus === CiBundleStatusEnum.ON_REMOVAL) {
     return (
-      <Alert severity={'error'} data-testid="alert-error-test" variant='outlined'>
+      <Alert severity={'error'} data-testid="alert-error-test" variant="outlined">
         {t('commissionBundlesPage.commissionBundleDetail.alert.onRemoval')}
       </Alert>
     );
@@ -58,7 +51,7 @@ function RenderAlert({ bundleDetail }: { bundleDetail: BundleResource }) {
   });
   if (expiredFound) {
     return (
-      <Alert severity={'warning'} data-testid="alert-warning-test" variant='outlined'>
+      <Alert severity={'warning'} data-testid="alert-warning-test" variant="outlined">
         {t('commissionBundlesPage.commissionBundleDetail.alert.expiredTaxonomies')}
       </Alert>
     );
@@ -69,14 +62,15 @@ function RenderAlert({ bundleDetail }: { bundleDetail: BundleResource }) {
 const BundleActionButtons = ({
   setShowConfirmModal,
   bundleDetail,
+  bundleId,
 }: {
   setShowConfirmModal: (arg: BundleDetailsActionTypes | null) => void;
   bundleDetail: BundleResource;
+  bundleId: string;
 }) => {
   const { t } = useTranslation();
   const { orgInfo } = useOrganizationType();
   const { userIsAdmin } = useUserRole();
-  const { bundleId } = useParams<{ bundleId: string }>();
 
   if (userIsAdmin) {
     if (orgInfo.types.isPsp) {
@@ -167,10 +161,10 @@ const CommissionBundleDetailPage = () => {
   const setLoading = useLoading(LOADING_TASK_COMMISSION_BUNDLE_DETAIL);
   const selectedParty: Party | undefined = useAppSelector(partiesSelectors.selectPartySelected);
   const addError = useErrorDispatcher();
-  const { bundleId } = useParams<{ bundleId: string }>();
 
   const commissionBundleDetail: BundleResource =
     useAppSelector(bundleDetailsSelectors.selectBundleDetails) ?? {};
+  const bundleId = commissionBundleDetail.idBundle ?? '';
   const [showConfirmModal, setShowConfirmModal] = useState<BundleDetailsActionTypes | null>(null);
 
   function handleModalAction() {
@@ -254,6 +248,7 @@ const CommissionBundleDetailPage = () => {
               <BundleActionButtons
                 setShowConfirmModal={setShowConfirmModal}
                 bundleDetail={commissionBundleDetail}
+                bundleId={bundleId}
               />
             </Stack>
           </Grid>
@@ -291,18 +286,20 @@ const CommissionBundleDetailPage = () => {
             )}
         </Grid>
       </SideMenuLayout>
-      {showConfirmModal && <GenericModal
-        title={t(`commissionBundlesPage.commissionBundleDetail.modal.title.${showConfirmModal}`)}
-        message={t(
-          `commissionBundlesPage.commissionBundleDetail.modal.message.${showConfirmModal}`
-        )}
-        openModal={showConfirmModal !== null}
-        onConfirmLabel={t('general.confirm')}
-        onCloseLabel={t('general.turnBack')}
-        handleCloseModal={() => setShowConfirmModal(null)}
-        handleConfirm={() => handleModalAction()}
-        data-testid="delete-modal"
-      />}
+      {showConfirmModal && (
+        <GenericModal
+          title={t(`commissionBundlesPage.commissionBundleDetail.modal.title.${showConfirmModal}`)}
+          message={t(
+            `commissionBundlesPage.commissionBundleDetail.modal.message.${showConfirmModal}`
+          )}
+          openModal={showConfirmModal !== null}
+          onConfirmLabel={t('general.confirm')}
+          onCloseLabel={t('general.turnBack')}
+          handleCloseModal={() => setShowConfirmModal(null)}
+          handleConfirm={() => handleModalAction()}
+          data-testid="delete-modal"
+        />
+      )}
     </>
   );
 };

--- a/src/pages/commisionalBundles/detail/components/subscriptions/CommissionBundleSubscriptionsDrawer.tsx
+++ b/src/pages/commisionalBundles/detail/components/subscriptions/CommissionBundleSubscriptionsDrawer.tsx
@@ -101,7 +101,7 @@ export const CommissionBundleSubscriptionsDrawer = ({
                   {el.specific_built_in_data}
                 </Typography>
                 <Typography variant="body1" fontWeight={'fontWeightMedium'}>
-                  {el.payment_amount ? formatCurrencyEur(el.payment_amount) : '-'}
+                  {formatCurrencyEur(el.payment_amount)}
                 </Typography>
               </Box>
             </Box>

--- a/src/pages/commisionalBundles/list/CommissionBundlesTable.tsx
+++ b/src/pages/commisionalBundles/list/CommissionBundlesTable.tsx
@@ -60,6 +60,7 @@ const CommissionBundlesTable = ({ bundleNameFilter, bundleType }: Props) => {
   const [page, setPage] = useState(0);
   const brokerCode = selectedParty?.fiscalCode ?? '';
   const [isFirstRender, setIsFirstRender] = useState<boolean>(true);
+  const mappedBundleType = mapBundle(bundleType);
 
   const setLoadingStatus = (status: boolean) => {
     setLoading(status);
@@ -71,7 +72,6 @@ const CommissionBundlesTable = ({ bundleNameFilter, bundleType }: Props) => {
     if (isFirstRender) {
       setIsFirstRender(false);
     }
-    const mappedBundleType = mapBundle(bundleType);
     // eslint-disable-next-line functional/no-let
     let promise;
     if (orgInfo.types.isPsp) {
@@ -143,6 +143,7 @@ const CommissionBundlesTable = ({ bundleNameFilter, bundleType }: Props) => {
   return (
     <Box
       id="commissionBundlesTable"
+      data-testid={`table-${mappedBundleType}`}
       sx={{
         position: 'relative',
         width: '100% !important',

--- a/src/pages/delegations/detail/DelegationDetailPage.tsx
+++ b/src/pages/delegations/detail/DelegationDetailPage.tsx
@@ -10,7 +10,7 @@ import { CreditorInstitutionContactsResource } from '../../../api/generated/port
 import SideMenuLayout from '../../../components/SideMenu/SideMenuLayout';
 import TableSearchBar from '../../../components/Table/TableSearchBar';
 import { Party } from '../../../model/Party';
-import { useAppSelector } from '../../../redux/hooks';
+import { useAppSelector, useAppSelectorWithRedirect } from '../../../redux/hooks';
 import { delegationDetailSelectors } from '../../../redux/slices/delegationDetailSlice';
 import { partiesSelectors } from '../../../redux/slices/partiesSlice';
 import ROUTES from '../../../routes';
@@ -31,7 +31,10 @@ const DelegationDetailPage = () => {
   const setLoading = useLoading(LOADING_TASK_CI_DELEGATION_CONTACTS_LIST);
 
   const delegationDetail: CIBrokerDelegationResource =
-    useAppSelector(delegationDetailSelectors.selectDelegationDetail) ?? {};
+    useAppSelectorWithRedirect(
+      delegationDetailSelectors.selectDelegationDetail,
+      ROUTES.DELEGATIONS_LIST
+    ) ?? {};
 
   useEffect(() => {
     setLoading(true);

--- a/src/pages/delegations/detail/__tests__/DelegationDetailPage.test.tsx
+++ b/src/pages/delegations/detail/__tests__/DelegationDetailPage.test.tsx
@@ -6,6 +6,9 @@ import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { store } from '../../../../redux/store';
 import DelegationDetailPage from '../DelegationDetailPage';
+import { delegationDetailActions } from '../../../../redux/slices/delegationDetailSlice';
+import { mockedCIDelegations } from '../../../../services/__mocks__/brokerService';
+import { useAppDispatch } from '../../../../redux/hooks';
 
 beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -14,17 +17,26 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
+const ComponentRender = () => {
+  const dispatcher = useAppDispatch();
+  dispatcher(delegationDetailActions.setDelegationDetailState(mockedCIDelegations[0]));
+
+  return (
+    <MemoryRouter initialEntries={[`/delegations-list/detail`]}>
+      <Route path="/delegations-list/detail">
+        <ThemeProvider theme={theme}>
+          <DelegationDetailPage />
+        </ThemeProvider>
+      </Route>
+    </MemoryRouter>
+  );
+};
+
 describe('<DelegationDetailPage />', () => {
   test('render component DelegationDetailPage', async () => {
     render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[`/delegations-list/detail`]}>
-          <Route path="/delegations-list/detail">
-            <ThemeProvider theme={theme}>
-              <DelegationDetailPage />
-            </ThemeProvider>
-          </Route>
-        </MemoryRouter>
+        <ComponentRender />
       </Provider>
     );
 

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,6 +1,23 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import type { RootState, AppDispatch } from './store';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export const useAppSelectorWithRedirect = (
+  selector: (state: RootState) => any,
+  routeToRedirect?: string
+) => {
+  const selectedReduxState = useAppSelector(selector);
+  const history = useHistory();
+  if (
+    routeToRedirect &&
+    (!selectedReduxState ||
+      (typeof selectedReduxState === 'object' && Object.keys(selectedReduxState).length === 0))
+  ) {
+    history.push(routeToRedirect);
+  }
+  return selectedReduxState;
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Fixed rendering of commission bundle's CI request fees, it was rendering "-" instead of 0
- The bundle table's tab value is now the type of the last bundle selected from the user in the redux state, when is not present the default is GLOBAL
- Removed the usage of the bundleId from the url params that could have caused security issues
- Added a new hook to redirect user to defined page when the requested redux state is empty

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
[VAS-1022](https://pagopa.atlassian.net/browse/VAS-1022?atlOrigin=eyJpIjoiM2M3ZmQ2ODA5MWVjNGNjZWFkMzExMjRmMjZjY2Y2YTQiLCJwIjoiaiJ9)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[VAS-1022]: https://pagopa.atlassian.net/browse/VAS-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ