### PR TITLE
[VAS-1030] feat: Implement "all taxonomy" commission fee

### DIFF
--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -1062,7 +1062,8 @@
         "errorMessageNoBrokerDelegations": "L’intermediario non ha ancora effettuato la registrazione al Nodo dei Pagamenti",
         "errorMessageNoBroker": "Non sono presenti intermediari"
       }
-    }
+    },
+    "allTaxonomies": "Tutti i servizi di incasso"
   },
   "addEditOperationTableForm": {
     "title": "Tavolo Operativo",

--- a/src/pages/commisionalBundles/detail/components/CommissionBundleDetailTaxonomies.tsx
+++ b/src/pages/commisionalBundles/detail/components/CommissionBundleDetailTaxonomies.tsx
@@ -24,7 +24,7 @@ const TaxonomyBox = ({ taxonomy }: { taxonomy: BundleTaxonomy }) => {
         {taxonomy.serviceType}
       </Typography>
       <Typography variant="body1" fontWeight={'fontWeightMedium'}>
-        {getSpecificBuiltInData(t, taxonomy)}
+        {getSpecificBuiltInData(t, taxonomy.specificBuiltInData)}
       </Typography>
       {(taxonomy as CIBundleFee).paymentAmount !== undefined && (
         <Box display="flex" justifyContent={'space-between'} mt={0.5} data-testid="ci-bundle-fee">

--- a/src/pages/commisionalBundles/detail/components/CommissionBundleDetailTaxonomies.tsx
+++ b/src/pages/commisionalBundles/detail/components/CommissionBundleDetailTaxonomies.tsx
@@ -12,6 +12,7 @@ import {
   CIBundleResource,
   CiBundleStatusEnum,
 } from '../../../../api/generated/portal/CIBundleResource';
+import { getSpecificBuiltInData } from '../../../../services/bundleService';
 
 const componentPath = 'commissionBundlesPage.commissionBundleDetail';
 
@@ -23,7 +24,7 @@ const TaxonomyBox = ({ taxonomy }: { taxonomy: BundleTaxonomy }) => {
         {taxonomy.serviceType}
       </Typography>
       <Typography variant="body1" fontWeight={'fontWeightMedium'}>
-        {taxonomy.specificBuiltInData}
+        {getSpecificBuiltInData(t, taxonomy)}
       </Typography>
       {(taxonomy as CIBundleFee).paymentAmount !== undefined && (
         <Box display="flex" justifyContent={'space-between'} mt={0.5} data-testid="ci-bundle-fee">
@@ -69,7 +70,7 @@ export default function CommissionBundleDetailTaxonomies({
       {bundleTaxonomies.length > 0 ? (
         bundleTaxonomies?.slice(0, 3)?.map((el: BundleTaxonomy, i: number) =>
           i < 4 ? (
-            <Box key={`taxonomy-${el.specificBuiltInData}`} mt={1} data-testid="taxonomy-column">
+            <Box key={`taxonomy-${el.specificBuiltInData ?? "all"}`} mt={1} data-testid="taxonomy-column">
               <TaxonomyBox taxonomy={el} />
             </Box>
           ) : null

--- a/src/pages/commisionalBundles/detail/components/subscriptions/CommissionBundleSubscriptionsDrawer.tsx
+++ b/src/pages/commisionalBundles/detail/components/subscriptions/CommissionBundleSubscriptionsDrawer.tsx
@@ -100,7 +100,7 @@ export const CommissionBundleSubscriptionsDrawer = ({
               </Typography>
               <Box display="flex" justifyContent="space-between">
                 <Typography variant="body1" fontWeight={'fontWeightMedium'}>
-                  {getSpecificBuiltInData(t, el)}
+                  {getSpecificBuiltInData(t, el.specificBuiltInData)}
                 </Typography>
                 <Typography variant="body1" fontWeight={'fontWeightMedium'}>
                   {formatCurrencyEur(el.paymentAmount)}

--- a/src/pages/commisionalBundles/detail/components/subscriptions/CommissionBundleSubscriptionsDrawer.tsx
+++ b/src/pages/commisionalBundles/detail/components/subscriptions/CommissionBundleSubscriptionsDrawer.tsx
@@ -6,6 +6,7 @@ import { TFunction } from 'react-i18next';
 import { PaddedDrawer } from '../../../../../components/PaddedDrawer';
 import { CIBundleFee } from '../../../../../api/generated/portal/CIBundleFee';
 import { formatCurrencyEur } from '../../../../../utils/common-utils';
+import { getSpecificBuiltInData } from '../../../../../services/bundleService';
 import {
   PublicBundleCiSubscriptionDetailModel,
   SubscriptionStateType,
@@ -51,7 +52,8 @@ export const CommissionBundleSubscriptionsDrawer = ({
       t,
       stateType,
       setOpenMenageSubscriptionModal,
-      selectedSubscriptionRequest.ci_bundle_fee_list !== undefined && !selectedSubscriptionRequest.on_removal
+      selectedSubscriptionRequest.ci_bundle_fee_list !== undefined &&
+        !selectedSubscriptionRequest.on_removal
     )}
   >
     <TitleBox title={t(`${componentPath}.title`)} variantTitle="h5" />
@@ -92,13 +94,13 @@ export const CommissionBundleSubscriptionsDrawer = ({
           </Box>
 
           {selectedSubscriptionRequest?.ci_bundle_fee_list?.map((el: CIBundleFee) => (
-            <Box mb={1} key={`taxonomies-list-${el.specificBuiltInData}`}>
+            <Box mb={1} key={`taxonomies-list-${el.specificBuiltInData ?? 'all'}`}>
               <Typography variant="body1" color="action.active">
                 {el.serviceType}
               </Typography>
               <Box display="flex" justifyContent="space-between">
                 <Typography variant="body1" fontWeight={'fontWeightMedium'}>
-                  {el.specificBuiltInData}
+                  {getSpecificBuiltInData(t, el)}
                 </Typography>
                 <Typography variant="body1" fontWeight={'fontWeightMedium'}>
                   {formatCurrencyEur(el.paymentAmount)}

--- a/src/services/__tests__/bundleService.test.ts
+++ b/src/services/__tests__/bundleService.test.ts
@@ -1,6 +1,7 @@
 import { BackofficeApi } from '../../api/BackofficeClient';
 import { TypeEnum } from '../../api/generated/portal/BundleRequest';
 import { SubscriptionStateType } from '../../model/CommissionBundle';
+import { mockedTaxonomy } from '../__mocks__/taxonomyService';
 import {
   mockedBundleCreateResponse,
   mockedBundleRequest,
@@ -11,6 +12,7 @@ import {
   mockedCommissionBundleCiList,
   mockedCommissionBundlePspDetailGlobal,
   mockedCommissionBundlePspList,
+  mockedPSPTaxonomyList,
   mockedTouchpoints,
 } from '../__mocks__/bundleService';
 import {
@@ -25,6 +27,7 @@ import {
   getCisBundles,
   getPublicBundleCISubscriptions,
   getPublicBundleCISubscriptionsDetail,
+  getSpecificBuiltInData,
   getTouchpoints,
   rejectPublicBundleSubscription,
   updatePSPBundle,
@@ -234,3 +237,15 @@ describe('BundleService test client', () => {
     expect(spyOn).toBeCalledTimes(1);
   });
 });
+
+describe("Test BundleService utils", () => {
+  const mockTFunc = (path: string) => ("mockTFunc");
+  let taxonomy = mockedPSPTaxonomyList[0];
+  test("getSpecificBuiltInData taxonomy id present", () => {
+    expect(getSpecificBuiltInData(mockTFunc, taxonomy)).toBe(taxonomy.specificBuiltInData);
+  });
+  test("getSpecificBuiltInData taxonomy id null", () => {
+    taxonomy.specificBuiltInData = undefined;
+    expect(getSpecificBuiltInData(mockTFunc, taxonomy)).toBe(mockTFunc(""));
+  });
+})

--- a/src/services/__tests__/bundleService.test.ts
+++ b/src/services/__tests__/bundleService.test.ts
@@ -1,14 +1,12 @@
 import { BackofficeApi } from '../../api/BackofficeClient';
 import { TypeEnum } from '../../api/generated/portal/BundleRequest';
 import { SubscriptionStateType } from '../../model/CommissionBundle';
-import { mockedTaxonomy } from '../__mocks__/taxonomyService';
 import {
   mockedBundleCreateResponse,
   mockedBundleRequest,
   mockedCIBundleRequest,
   mockedCiSubscriptionDetail,
   mockedCiSubscriptionList,
-  mockedCommissionBundleCiDetailGlobal,
   mockedCommissionBundleCiList,
   mockedCommissionBundlePspDetailGlobal,
   mockedCommissionBundlePspList,
@@ -242,10 +240,10 @@ describe("Test BundleService utils", () => {
   const mockTFunc = (path: string) => ("mockTFunc");
   let taxonomy = mockedPSPTaxonomyList[0];
   test("getSpecificBuiltInData taxonomy id present", () => {
-    expect(getSpecificBuiltInData(mockTFunc, taxonomy)).toBe(taxonomy.specificBuiltInData);
+    expect(getSpecificBuiltInData(mockTFunc, taxonomy.specificBuiltInData)).toBe(taxonomy.specificBuiltInData);
   });
   test("getSpecificBuiltInData taxonomy id null", () => {
     taxonomy.specificBuiltInData = undefined;
-    expect(getSpecificBuiltInData(mockTFunc, taxonomy)).toBe(mockTFunc(""));
+    expect(getSpecificBuiltInData(mockTFunc, taxonomy.specificBuiltInData)).toBe(mockTFunc(""));
   });
 })

--- a/src/services/bundleService.ts
+++ b/src/services/bundleService.ts
@@ -229,7 +229,7 @@ export const createCIBundleRequest = ({
   }
 };
 
-export const getSpecificBuiltInData = (t: TFunction, taxonomy?: BundleTaxonomy) =>
-  taxonomy?.specificBuiltInData
-    ? taxonomy?.specificBuiltInData
+export const getSpecificBuiltInData = (t: TFunction, specificBuiltInData?: string) =>
+  specificBuiltInData
+    ? specificBuiltInData
     : t('commissionBundlesPage.allTaxonomies');

--- a/src/services/bundleService.ts
+++ b/src/services/bundleService.ts
@@ -1,8 +1,10 @@
+import { TFunction } from 'react-i18next';
 import { BackofficeApi } from '../api/BackofficeClient';
 import { BundleCreateResponse } from '../api/generated/portal/BundleCreateResponse';
 import { BundleRequest } from '../api/generated/portal/BundleRequest';
 import { Touchpoints } from '../api/generated/portal/Touchpoints';
 import {
+  BundleTaxonomy,
   PublicBundleCiSubscriptionsDetailMethodParams,
   PublicBundleCISubscriptionsMethodParams,
 } from '../model/CommissionBundle';
@@ -226,3 +228,8 @@ export const createCIBundleRequest = ({
     });
   }
 };
+
+export const getSpecificBuiltInData = (t: TFunction, taxonomy?: BundleTaxonomy) =>
+  taxonomy?.specificBuiltInData
+    ? taxonomy?.specificBuiltInData
+    : t('commissionBundlesPage.allTaxonomies');


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Implemented handling of empty CI's public bundle attributes as commission fee for all taxonomies in:
    - CI's Bundle activation page
    - CI's Bundle detail page
    - PSP's Public Bundle subscription request drawer
- Updated unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
[VAS-1030](https://pagopa.atlassian.net/browse/VAS-1030?atlOrigin=eyJpIjoiOWU2N2UyOGY5ZTY3NDZiY2I0ODlhM2IyZjQxMzVkY2UiLCJwIjoiaiJ9)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[VAS-1030]: https://pagopa.atlassian.net/browse/VAS-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ