### PR TITLE
fix: PSP bundle state without validity date to

### DIFF
--- a/src/pages/commisionalBundles/list/CommissionBundlesTableColumns.tsx
+++ b/src/pages/commisionalBundles/list/CommissionBundlesTableColumns.tsx
@@ -15,7 +15,10 @@ import {
   showCustomHeader,
 } from '../../../components/Table/TableUtils';
 import { BundleResource } from '../../../model/CommissionBundle';
-import { CIBundleResource, CiBundleStatusEnum } from '../../../api/generated/portal/CIBundleResource';
+import {
+  CIBundleResource,
+  CiBundleStatusEnum,
+} from '../../../api/generated/portal/CIBundleResource';
 import { TypeEnum } from '../../../api/generated/portal/PSPBundleResource';
 
 export function buildColumnDefs(
@@ -182,28 +185,26 @@ const getPSPStatusChip = (
   validityDateTo: Date | undefined,
   validityDateFrom: Date
 ) => {
-  if(validityDateTo){
-    if (datesAreOnSameDay(todayDate, validityDateTo)) {
-      return renderStatusChip({
-        chipColor: 'error',
-        chipLabel: t('commissionBundlesPage.list.states.eliminating'),
-        dataTestId: 'error-state-chip',
-      });
-    }
-    if (todayDate.getTime() < validityDateFrom.getTime()) {
-      return renderStatusChip({
-        chipColor: 'default',
-        chipLabel: t('commissionBundlesPage.list.states.inActivation'),
-        dataTestId: 'default-state-chip',
-      });
-    }
-    if (dateDifferenceInDays(todayDate, validityDateTo) <= 7) {
-      return renderStatusChip({
-        chipColor: 'warning',
-        chipLabel: t('commissionBundlesPage.list.states.expiring'),
-        dataTestId: 'warning-state-chip',
-      });
-    }
+  if (validityDateTo && datesAreOnSameDay(todayDate, validityDateTo)) {
+    return renderStatusChip({
+      chipColor: 'error',
+      chipLabel: t('commissionBundlesPage.list.states.eliminating'),
+      dataTestId: 'error-state-chip',
+    });
+  }
+  if (todayDate.getTime() < validityDateFrom.getTime()) {
+    return renderStatusChip({
+      chipColor: 'default',
+      chipLabel: t('commissionBundlesPage.list.states.inActivation'),
+      dataTestId: 'default-state-chip',
+    });
+  }
+  if (validityDateTo && dateDifferenceInDays(todayDate, validityDateTo) <= 7) {
+    return renderStatusChip({
+      chipColor: 'warning',
+      chipLabel: t('commissionBundlesPage.list.states.expiring'),
+      dataTestId: 'warning-state-chip',
+    });
   }
 
   return renderStatusChip({
@@ -245,7 +246,7 @@ const getCIStatusChip = (
     if (bundleStatus === CiBundleStatusEnum.REQUESTED) {
       return (
         <Chip
-          sx={{backgroundColor: "#7ED5FC"}}
+          sx={{ backgroundColor: '#7ED5FC' }}
           label={t('commissionBundlesPage.list.states.requestInProgress')}
           data-testid="primary-state-chip"
         />

--- a/src/pages/commisionalBundles/list/CommissionBundlesTableColumns.tsx
+++ b/src/pages/commisionalBundles/list/CommissionBundlesTableColumns.tsx
@@ -159,7 +159,7 @@ export const getStateChip = (
   const validityDateTo = bundleDetails.validityDateTo;
   const todayDate = new Date();
 
-  if (isPsp && validityDateFrom && validityDateTo) {
+  if (isPsp && validityDateFrom) {
     return getPSPStatusChip(t, todayDate, validityDateTo, validityDateFrom);
   }
   if (isCi) {
@@ -179,29 +179,31 @@ export const getStateChip = (
 const getPSPStatusChip = (
   t: TFunction<'translation'>,
   todayDate: Date,
-  validityDateTo: Date,
+  validityDateTo: Date | undefined,
   validityDateFrom: Date
 ) => {
-  if (datesAreOnSameDay(todayDate, validityDateTo)) {
-    return renderStatusChip({
-      chipColor: 'error',
-      chipLabel: t('commissionBundlesPage.list.states.eliminating'),
-      dataTestId: 'error-state-chip',
-    });
-  }
-  if (todayDate.getTime() < validityDateFrom.getTime()) {
-    return renderStatusChip({
-      chipColor: 'default',
-      chipLabel: t('commissionBundlesPage.list.states.inActivation'),
-      dataTestId: 'default-state-chip',
-    });
-  }
-  if (dateDifferenceInDays(todayDate, validityDateTo) <= 7) {
-    return renderStatusChip({
-      chipColor: 'warning',
-      chipLabel: t('commissionBundlesPage.list.states.expiring'),
-      dataTestId: 'warning-state-chip',
-    });
+  if(validityDateTo){
+    if (datesAreOnSameDay(todayDate, validityDateTo)) {
+      return renderStatusChip({
+        chipColor: 'error',
+        chipLabel: t('commissionBundlesPage.list.states.eliminating'),
+        dataTestId: 'error-state-chip',
+      });
+    }
+    if (todayDate.getTime() < validityDateFrom.getTime()) {
+      return renderStatusChip({
+        chipColor: 'default',
+        chipLabel: t('commissionBundlesPage.list.states.inActivation'),
+        dataTestId: 'default-state-chip',
+      });
+    }
+    if (dateDifferenceInDays(todayDate, validityDateTo) <= 7) {
+      return renderStatusChip({
+        chipColor: 'warning',
+        chipLabel: t('commissionBundlesPage.list.states.expiring'),
+        dataTestId: 'warning-state-chip',
+      });
+    }
   }
 
   return renderStatusChip({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Changed PSP bundle state logic to show state even if validityDateTo is undefined

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Some bundles don't have the expire date and were causing the state chip to not render

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
