### PR TITLE
[PIDM-160] fix(CreateStationMaintenance): Adjust fromHours and toHours to handle GMT+2 - GMT+1 correctly

### DIFF
--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -1690,7 +1690,7 @@
       "errorGetStations": "E' stato riscontrato un errore durante il recupero delle stazioni",
       "hoursSection": {
         "title": "Quando sarà in manutenzione?",
-        "subtitle": "Timezone: Rome, Italy (GMT +1:00)",
+        "subtitle": "Timezone: Rome, Italy",
         "totalHours": "Totale ore",
         "fromHours": "Dalle ore",
         "toHours": "Alle ore",

--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -1690,7 +1690,7 @@
       "errorGetStations": "E' stato riscontrato un errore durante il recupero delle stazioni",
       "hoursSection": {
         "title": "Quando sarà in manutenzione?",
-        "subtitle": "Timezone: Rome, Italy (GMT +2:00)",
+        "subtitle": "Timezone: Rome, Italy (GMT +1:00)",
         "totalHours": "Totale ore",
         "fromHours": "Dalle ore",
         "toHours": "Alle ore",

--- a/src/pages/stationMaintenances/addEditDetail/StationMaintenanceAddEditDetail.tsx
+++ b/src/pages/stationMaintenances/addEditDetail/StationMaintenanceAddEditDetail.tsx
@@ -34,7 +34,7 @@ import {
   StationMaintenanceActionType,
   StationMaintenanceState,
 } from '../../../model/StationMaintenance';
-import { datesAreOnSameDay, formatDateToDDMMYYYYhhmmWithTimezone, removeDateZoneInfoGMT2 } from '../../../utils/common-utils';
+import { datesAreOnSameDay, formatDateToDDMMYYYYhhmmWithTimezone, removeDateZoneInfoGMT1 } from '../../../utils/common-utils';
 import { useAppSelector, useAppSelectorWithRedirect } from '../../../redux/hooks';
 import { partiesSelectors } from '../../../redux/slices/partiesSlice';
 import { getStations } from '../../../services/stationService';
@@ -254,9 +254,9 @@ export default function StationMaintenanceAddEditDetail() {
       }
       let promise;
       const body: CreateStationMaintenance = {
-        end_date_time: removeDateZoneInfoGMT2(mergeDateAndHours(dateTo, hoursTo))!,
+        end_date_time: removeDateZoneInfoGMT1(mergeDateAndHours(dateTo, hoursTo))!,
         stand_in: standIn,
-        start_date_time: removeDateZoneInfoGMT2(mergeDateAndHours(dateFrom, hoursFrom))!,
+        start_date_time: removeDateZoneInfoGMT1(mergeDateAndHours(dateFrom, hoursFrom))!,
         station_code: selectedStation?.stationCode ?? '',
       };
       if (action === StationMaintenanceActionType.CREATE) {

--- a/src/pages/stationMaintenances/addEditDetail/StationMaintenanceAddEditDetail.tsx
+++ b/src/pages/stationMaintenances/addEditDetail/StationMaintenanceAddEditDetail.tsx
@@ -34,7 +34,7 @@ import {
   StationMaintenanceActionType,
   StationMaintenanceState,
 } from '../../../model/StationMaintenance';
-import { datesAreOnSameDay, formatDateToDDMMYYYYhhmmWithTimezone, removeDateZoneInfoGMT1 } from '../../../utils/common-utils';
+import { datesAreOnSameDay, formatDateToDDMMYYYYhhmmWithTimezone, removeDateZoneInfoGMT } from '../../../utils/common-utils';
 import { useAppSelector, useAppSelectorWithRedirect } from '../../../redux/hooks';
 import { partiesSelectors } from '../../../redux/slices/partiesSlice';
 import { getStations } from '../../../services/stationService';
@@ -254,11 +254,12 @@ export default function StationMaintenanceAddEditDetail() {
       }
       let promise;
       const body: CreateStationMaintenance = {
-        end_date_time: removeDateZoneInfoGMT1(mergeDateAndHours(dateTo, hoursTo))!,
+        end_date_time: removeDateZoneInfoGMT(mergeDateAndHours(dateTo, hoursTo))!,
         stand_in: standIn,
-        start_date_time: removeDateZoneInfoGMT1(mergeDateAndHours(dateFrom, hoursFrom))!,
+        start_date_time: removeDateZoneInfoGMT(mergeDateAndHours(dateFrom, hoursFrom))!,
         station_code: selectedStation?.stationCode ?? '',
       };
+      console.log(JSON.stringify(body));
       if (action === StationMaintenanceActionType.CREATE) {
         promise = createStationMaintenance({
           brokerTaxCode: selectedParty?.fiscalCode ?? '',

--- a/src/pages/stationMaintenances/addEditDetail/StationMaintenanceAddEditDetail.tsx
+++ b/src/pages/stationMaintenances/addEditDetail/StationMaintenanceAddEditDetail.tsx
@@ -259,7 +259,6 @@ export default function StationMaintenanceAddEditDetail() {
         start_date_time: removeDateZoneInfoGMT(mergeDateAndHours(dateFrom, hoursFrom))!,
         station_code: selectedStation?.stationCode ?? '',
       };
-      console.log(JSON.stringify(body));
       if (action === StationMaintenanceActionType.CREATE) {
         promise = createStationMaintenance({
           brokerTaxCode: selectedParty?.fiscalCode ?? '',

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -84,13 +84,7 @@ export const removeDateZoneInfo = (value: Date | undefined): Date | undefined =>
   return new Date(value.getTime() - userTimezoneOffset);
 };
 
-export const removeDateZoneInfoGMT1 = (value: Date | undefined): Date | undefined => {
-  if (!value) {
-    return value;
-  }
-  const userTimezoneOffset = (value.getTimezoneOffset() + 60) * 60000;
-  return new Date(value.getTime() - userTimezoneOffset);
-};
+export const removeDateZoneInfoGMT = (value: Date | undefined): Date | undefined => value && new Date(value.getTime());
 
 export const formatDateToDDMMYYYYhhmm = (value: any): string =>
   value.toLocaleString('en-GB', {
@@ -109,14 +103,9 @@ export const formatDateTohhmm = (value: any): string =>
 
 export const formatDateToDDMMYYYYhhmmWithTimezone = (value: any, swapMonthDay?: boolean): string => {
   const timeZone = 'Europe/Rome';
-
-  const dt = DateTime.fromJSDate(value, { zone: timeZone });
-  const now = DateTime.now().setZone(timeZone);
-
-  const offset = now.offset - dt.offset;
-  const adjustedDate = dt.plus({ minutes: offset });
-
-  return adjustedDate.toFormat(swapMonthDay ? 'MM/dd/yyyy, HH:mm' : 'dd/MM/yyyy, HH:mm');
+  const utcDate = DateTime.fromISO(value.toISOString(), { zone: "utc" });
+  const localDate = utcDate.setZone(timeZone);
+  return localDate.toFormat(swapMonthDay ? 'MM/dd/yyyy, HH:mm' : 'dd/MM/yyyy, HH:mm');
 };
 
 export const formatDateToYYYYMMDD = (value: any): string => value.toISOString().split('T')[0];

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -84,11 +84,11 @@ export const removeDateZoneInfo = (value: Date | undefined): Date | undefined =>
   return new Date(value.getTime() - userTimezoneOffset);
 };
 
-export const removeDateZoneInfoGMT2 = (value: Date | undefined): Date | undefined => {
+export const removeDateZoneInfoGMT1 = (value: Date | undefined): Date | undefined => {
   if (!value) {
     return value;
   }
-  const userTimezoneOffset = (value.getTimezoneOffset() + 120) * 60000;
+  const userTimezoneOffset = (value.getTimezoneOffset() + 60) * 60000;
   return new Date(value.getTime() - userTimezoneOffset);
 };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Adjust fromHours and toHours to handle GMT+2 to GMT+1 correctly

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This update ensures that when a user enters a maintenance date, the portal correctly saves and displays the date while accounting for daylight saving time (DST) transitions. Previously, the system only considered GMT+2, which caused inconsistencies when users selected a date that falls within GMT+1 due to DST changes. This fix properly adjusts for these variations, ensuring accurate date storage and display.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local testing
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
