### PR TITLE
[PIDM-1684] Bug fix during psp association

### DIFF
--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -503,7 +503,8 @@
       "successMessage": "PSP associato con successo.",
       "errorMessageDesc": "Non è stato possibile associare il PSP al canale",
       "backButton": "Annulla",
-      "confirmButton": "Conferma"
+      "confirmButton": "Conferma",
+      "alreadyAssociated": "Già associato"
     }
   },
   "addEditStationPage": {

--- a/src/pages/channels/channelAssociatePSP/ChannelAssociatePSPPage.tsx
+++ b/src/pages/channels/channelAssociatePSP/ChannelAssociatePSPPage.tsx
@@ -21,7 +21,6 @@ import ROUTES from '../../../routes';
 import {
     associatePSPtoChannel,
     getChannelDetail,
-    getChannelPSPs,
 } from '../../../services/channelService';
 import { getBrokerDelegation } from '../../../services/institutionService';
 import { addCurrentPSP } from '../../../utils/channel-utils';
@@ -38,7 +37,6 @@ function ChannelAssociatePSPPage() {
 
     const [selectedPSP, setSelectedPSP] = useState<Delegation | undefined>();
     const [availablePSP, setAvailablePSP] = useState<Array<Delegation>>([]);
-    const [associatedPSPTaxCodes, setAssociatedPSPTaxCodes] = useState<Set<string>>(new Set());
     const [channelDetail, setChannelDetail] = useState<ChannelDetailsResource>();
 
     const formik = useFormik({
@@ -50,6 +48,8 @@ function ChannelAssociatePSPPage() {
     });
 
     const history = useHistory();
+    const associatedPSPTaxCodes: Array<string> =
+        (history.location.state as any)?.associatedPSPTaxCodes ?? [];
 
     const goBack = () => {
         history.push(
@@ -98,18 +98,6 @@ function ChannelAssociatePSPPage() {
         if (selectedParty) {
             getChannelDetail({channelCode: channelId, status: ConfigurationStatus.ACTIVE})
                 .then((channel) => setChannelDetail(channel))
-                .catch((reason) => console.error(reason));
-
-            // Fetch already associated PSPs to disable them in the selection list
-            getChannelPSPs(channelId, '', 0, 1000)
-                .then((data) => {
-                    const taxCodes = new Set(
-                        (data?.payment_service_providers ?? [])
-                            .map((psp) => psp.tax_code)
-                            .filter((tc): tc is string => !!tc)
-                    );
-                    setAssociatedPSPTaxCodes(taxCodes);
-                })
                 .catch((reason) => console.error(reason));
 
             getBrokerDelegation(undefined, selectedParty?.partyId, ["PSP"])

--- a/src/pages/channels/channelAssociatePSP/ChannelAssociatePSPPage.tsx
+++ b/src/pages/channels/channelAssociatePSP/ChannelAssociatePSPPage.tsx
@@ -21,6 +21,7 @@ import ROUTES from '../../../routes';
 import {
     associatePSPtoChannel,
     getChannelDetail,
+    getChannelPSPs,
 } from '../../../services/channelService';
 import { getBrokerDelegation } from '../../../services/institutionService';
 import { addCurrentPSP } from '../../../utils/channel-utils';
@@ -37,6 +38,7 @@ function ChannelAssociatePSPPage() {
 
     const [selectedPSP, setSelectedPSP] = useState<Delegation | undefined>();
     const [availablePSP, setAvailablePSP] = useState<Array<Delegation>>([]);
+    const [associatedPSPTaxCodes, setAssociatedPSPTaxCodes] = useState<Set<string>>(new Set());
     const [channelDetail, setChannelDetail] = useState<ChannelDetailsResource>();
 
     const formik = useFormik({
@@ -97,6 +99,19 @@ function ChannelAssociatePSPPage() {
             getChannelDetail({channelCode: channelId, status: ConfigurationStatus.ACTIVE})
                 .then((channel) => setChannelDetail(channel))
                 .catch((reason) => console.error(reason));
+
+            // Fetch already associated PSPs to disable them in the selection list
+            getChannelPSPs(channelId, '', 0, 1000)
+                .then((data) => {
+                    const taxCodes = new Set(
+                        (data?.payment_service_providers ?? [])
+                            .map((psp) => psp.tax_code)
+                            .filter((tc): tc is string => !!tc)
+                    );
+                    setAssociatedPSPTaxCodes(taxCodes);
+                })
+                .catch((reason) => console.error(reason));
+
             getBrokerDelegation(undefined, selectedParty?.partyId, ["PSP"])
                 .then((data) => {
                     if (data?.delegation_list && selectedParty) {
@@ -165,6 +180,7 @@ function ChannelAssociatePSPPage() {
                                     label={t('channelAssociatePSPPage.associationForm.PSPSelectionInputPlaceholder')}
                                     availablePSP={availablePSP}
                                     selectedPSP={selectedPSP}
+                                    associatedPSPTaxCodes={associatedPSPTaxCodes}
                                     onPSPSelectionChange={(selectedPSP: Delegation | undefined) => {
                                         setSelectedPSP(selectedPSP);
                                     }}

--- a/src/pages/channels/channelAssociatePSP/ChannelAssociatePSPPage.tsx
+++ b/src/pages/channels/channelAssociatePSP/ChannelAssociatePSPPage.tsx
@@ -23,7 +23,6 @@ import {
     getChannelDetail,
 } from '../../../services/channelService';
 import { getBrokerDelegation } from '../../../services/institutionService';
-import { getBrokerAndPspDetails } from '../../../services/nodeService';
 import { addCurrentPSP } from '../../../utils/channel-utils';
 import { LOADING_TASK_PSP_AVAILABLE } from '../../../utils/constants';
 import PSPSelectionSearch from './PSPSelectionSearch';
@@ -61,40 +60,33 @@ function ChannelAssociatePSPPage() {
     const handleSubmit = async () => {
         if (selectedPSP && selectedPSP.institution_id) {
             setLoading(true);
-
-            const pspToBeAssociatedDetails = selectedPSP.tax_code ? await getBrokerAndPspDetails(selectedPSP.tax_code) : null;
-
-            if (pspToBeAssociatedDetails?.paymentServiceProviderDetailsResource?.psp_code) {
+            try {
                 await associatePSPtoChannel(
                     channelId,
                     selectedPSP!.tax_code as string,
                     (channelDetail?.payment_types ?? []) as any
-                )
-                    .then((_data) => {
-                        history.push(
-                            generatePath(ROUTES.CHANNEL_PSP_LIST, {
-                                channelId,
-                            }),
-                            {
-                                alertSuccessMessage: t('channelAssociatePSPPage.associationForm.successMessage'),
-                            }
-                        );
-                    })
-                    .catch((reason) =>
-                        addError({
-                            id: 'ASSOCIATE_PSP',
-                            blocking: false,
-                            error: reason,
-                            techDescription: `An error occurred while psp association`,
-                            toNotify: true,
-                            displayableTitle: t('general.errorTitle'),
-                            displayableDescription: t('channelAssociatePSPPage.associationForm.errorMessageDesc'),
-                            component: 'Toast',
-                        })
-                    )
-                    .finally(() => {
-                        setLoading(false);
-                    });
+                );
+                history.push(
+                    generatePath(ROUTES.CHANNEL_PSP_LIST, {
+                        channelId,
+                    }),
+                    {
+                        alertSuccessMessage: t('channelAssociatePSPPage.associationForm.successMessage'),
+                    }
+                );
+            } catch (reason) {
+                addError({
+                    id: 'ASSOCIATE_PSP',
+                    blocking: false,
+                    error: reason as Error,
+                    techDescription: `An error occurred while psp association`,
+                    toNotify: true,
+                    displayableTitle: t('general.errorTitle'),
+                    displayableDescription: t('channelAssociatePSPPage.associationForm.errorMessageDesc'),
+                    component: 'Toast',
+                });
+            } finally {
+                setLoading(false);
             }
         }
     };

--- a/src/pages/channels/channelAssociatePSP/PSPSelectionSearch.tsx
+++ b/src/pages/channels/channelAssociatePSP/PSPSelectionSearch.tsx
@@ -1,6 +1,7 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import {Box, Grid} from '@mui/material';
 import {styled} from '@mui/material/styles';
+import {useTranslation} from 'react-i18next';
 import {PSP} from '../../../model/PSP';
 import {Delegation} from '../../../api/generated/portal/Delegation';
 import PSPSelectionSearchInput from './PSPSelectionSearchInput';
@@ -10,6 +11,7 @@ import PSPAccountItemSelection from './PSPAccountItemSelection';
 type Props = {
     availablePSP: Array<Delegation>;
     selectedPSP: Delegation | undefined;
+    associatedPSPTaxCodes?: Set<string>;
     onPSPSelectionChange: (selectedPSP: Delegation | undefined) => void;
     label?: string;
     iconColor?: string;
@@ -40,11 +42,13 @@ const CustomBox = styled(Box)({
 export default function PSPSelectionSearch({
                                                availablePSP,
                                                selectedPSP,
+                                               associatedPSPTaxCodes = new Set(),
                                                onPSPSelectionChange,
                                                label,
                                                iconColor,
                                                iconMarginRight,
                                            }: Props) {
+    const {t} = useTranslation();
     const [input, setInput] = useState<string>('');
     const [filteredParties, setFilteredParties] = useState<Array<Delegation>>([]);
 
@@ -100,17 +104,21 @@ export default function PSPSelectionSearch({
                     ) : (
                         <CustomBox>
                             {filteredParties &&
-                                filteredParties.map((PSP) => (
-                                    <PSPItemContainer
-                                        key={PSP.institution_id}
-                                        title={PSP.institution_name}
-                                        subTitle={/* t(roleLabels[PSP.userRole].longLabelKey) */ ''}
-                                        image={/* PSP.urlLogo */ ''}
-                                        action={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
-                                            handleListItemClick(event, PSP)
-                                        }
-                                    />
-                                ))}
+                                filteredParties.map((PSP) => {
+                                    const isAlreadyAssociated = !!(PSP.tax_code && associatedPSPTaxCodes.has(PSP.tax_code));
+                                    return (
+                                        <PSPItemContainer
+                                            key={PSP.institution_id}
+                                            title={PSP.institution_name}
+                                            subTitle={isAlreadyAssociated ? t('channelAssociatePSPPage.associationForm.alreadyAssociated') : ''}
+                                            image={''}
+                                            disabled={isAlreadyAssociated}
+                                            action={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
+                                                !isAlreadyAssociated && handleListItemClick(event, PSP)
+                                            }
+                                        />
+                                    );
+                                })}
                         </CustomBox>
                     )}
                 </Grid>

--- a/src/pages/channels/channelAssociatePSP/PSPSelectionSearch.tsx
+++ b/src/pages/channels/channelAssociatePSP/PSPSelectionSearch.tsx
@@ -11,7 +11,7 @@ import PSPAccountItemSelection from './PSPAccountItemSelection';
 type Props = {
     availablePSP: Array<Delegation>;
     selectedPSP: Delegation | undefined;
-    associatedPSPTaxCodes?: Set<string>;
+    associatedPSPTaxCodes?: Array<string>;
     onPSPSelectionChange: (selectedPSP: Delegation | undefined) => void;
     label?: string;
     iconColor?: string;
@@ -42,7 +42,7 @@ const CustomBox = styled(Box)({
 export default function PSPSelectionSearch({
                                                availablePSP,
                                                selectedPSP,
-                                               associatedPSPTaxCodes = new Set(),
+                                               associatedPSPTaxCodes = [],
                                                onPSPSelectionChange,
                                                label,
                                                iconColor,
@@ -105,7 +105,7 @@ export default function PSPSelectionSearch({
                         <CustomBox>
                             {filteredParties &&
                                 filteredParties.map((PSP) => {
-                                    const isAlreadyAssociated = !!(PSP.tax_code && associatedPSPTaxCodes.has(PSP.tax_code));
+                                    const isAlreadyAssociated = !!(PSP.tax_code && associatedPSPTaxCodes.includes(PSP.tax_code));
                                     return (
                                         <PSPItemContainer
                                             key={PSP.institution_id}

--- a/src/pages/channels/channelAssociatePSP/PSPSelectionSearchItemContainer.tsx
+++ b/src/pages/channels/channelAssociatePSP/PSPSelectionSearchItemContainer.tsx
@@ -6,9 +6,10 @@ type Props = {
     title: string | undefined;
     subTitle: string | undefined;
     image: string | undefined;
+    disabled?: boolean;
     action?: React.Dispatch<React.MouseEvent<HTMLDivElement, MouseEvent>>;
 };
-const PSPItemContainer = ({title, subTitle, image, action}: Props) => (
+const PSPItemContainer = ({title, subTitle, image, disabled = false, action}: Props) => (
     <Grid
         className={'selectedMoreThen3'}
         container
@@ -16,8 +17,9 @@ const PSPItemContainer = ({title, subTitle, image, action}: Props) => (
         direction={'row'}
         role={'Institution'}
         data-testid={`PartyItemContainer: ${title}`}
+        sx={disabled ? {opacity: 0.5, pointerEvents: 'none'} : {}}
         onKeyDownCapture={(e) => {
-            if (action && (e.key === 'Enter' || e.key === ' ')) {
+            if (!disabled && action && (e.key === 'Enter' || e.key === ' ')) {
                 action(e as any);
             }
         }}
@@ -27,8 +29,8 @@ const PSPItemContainer = ({title, subTitle, image, action}: Props) => (
             partyRole={subTitle as string}
             image={image}
             selectedItem={false}
-            action={action}
-            disabled={false}
+            action={disabled ? undefined : action}
+            disabled={disabled}
             maxCharactersNumberMultiLine={20}
         />
     </Grid>

--- a/src/pages/channels/channelAssociatePSP/__tests__/ChannelAssociatePSPPage.test.tsx
+++ b/src/pages/channels/channelAssociatePSP/__tests__/ChannelAssociatePSPPage.test.tsx
@@ -2,13 +2,13 @@ import {ThemeProvider} from '@mui/system';
 import {theme} from '@pagopa/mui-italia';
 import {cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import {createMemoryHistory} from 'history';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {createStore, store} from '../../../../redux/store';
 import {Provider} from 'react-redux';
 import ChannelAssociatePSPPage from '../ChannelAssociatePSPPage';
 import {pspAdminSignedDirect} from '../../../../services/__mocks__/partyService';
+import * as channelService from '../../../../services/channelService';
 
 const mockHistoryPush = jest.fn();
 
@@ -71,14 +71,6 @@ describe('<ChannelAssociatePSPPage />', () => {
         const searchInput = screen.getByTestId('psp-selection-search');
 
         await userEvent.type(searchInput, 'PSP1{enter}');
-
-        // const selection = screen.getByTestId('PartyItemContainer: PSP1');
-        // const selectionBtn = selection.querySelector('[role="button"]') as HTMLElement;
-        // await waitFor(() => fireEvent.click(selectionBtn));
-
-        // expect(confirm).not.toBeDisabled();
-
-        // await waitFor(() => fireEvent.click(confirm));
     });
 
     test('render component ChannelAssociatePSPPage and go back', async () => {
@@ -87,5 +79,66 @@ describe('<ChannelAssociatePSPPage />', () => {
         const back = screen.getByTestId('back-btn-test');
         await waitFor(() => fireEvent.click(back));
         expect(mockHistoryPush).toHaveBeenCalledWith(`ui/channels/${channelId}/psp-list`);
+    });
+
+    test('fetches already associated PSPs on mount', async () => {
+        const getChannelPSPsSpy = jest.spyOn(channelService, 'getChannelPSPs');
+
+        const {store} = renderApp();
+
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: pspAdminSignedDirect,
+            })
+        );
+
+        await waitFor(() => {
+            expect(getChannelPSPsSpy).toHaveBeenCalledWith(channelId, '', 0, 1000);
+        });
+
+        getChannelPSPsSpy.mockRestore();
+    });
+
+    test('handles getChannelPSPs failure gracefully', async () => {
+        const getChannelPSPsSpy = jest
+            .spyOn(channelService, 'getChannelPSPs')
+            .mockRejectedValueOnce(new Error('Network error'));
+
+        const {store} = renderApp();
+
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: pspAdminSignedDirect,
+            })
+        );
+
+        // The page should still render without crashing
+        const confirm = screen.getByTestId('confirm-btn-test');
+        expect(confirm).toBeDisabled();
+
+        getChannelPSPsSpy.mockRestore();
+    });
+
+    test('handles associatePSPtoChannel failure with error toast', async () => {
+        const associateSpy = jest
+            .spyOn(channelService, 'associatePSPtoChannel')
+            .mockRejectedValueOnce(new Error('Association failed'));
+
+        const {store} = renderApp();
+
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: pspAdminSignedDirect,
+            })
+        );
+
+        // Confirm button should be disabled when no PSP is selected
+        const confirm = screen.getByTestId('confirm-btn-test');
+        expect(confirm).toBeDisabled();
+
+        associateSpy.mockRestore();
     });
 });

--- a/src/pages/channels/channelAssociatePSP/__tests__/ChannelAssociatePSPPage.test.tsx
+++ b/src/pages/channels/channelAssociatePSP/__tests__/ChannelAssociatePSPPage.test.tsx
@@ -2,24 +2,28 @@ import {ThemeProvider} from '@mui/system';
 import {theme} from '@pagopa/mui-italia';
 import {cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import {createMemoryHistory} from 'history';
 import {MemoryRouter, Route} from 'react-router-dom';
-import {createStore, store} from '../../../../redux/store';
+import {createStore} from '../../../../redux/store';
 import {Provider} from 'react-redux';
 import ChannelAssociatePSPPage from '../ChannelAssociatePSPPage';
 import {pspAdminSignedDirect} from '../../../../services/__mocks__/partyService';
 import * as channelService from '../../../../services/channelService';
 
 const mockHistoryPush = jest.fn();
+let mockLocationState: any = {};
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useHistory: () => ({
         push: mockHistoryPush,
+        location: {state: mockLocationState},
     }),
 }));
 
 beforeEach(() => {
+    mockLocationState = {};
     jest.spyOn(console, 'error').mockImplementation(() => {
     });
     jest.spyOn(console, 'warn').mockImplementation(() => {
@@ -74,15 +78,15 @@ describe('<ChannelAssociatePSPPage />', () => {
     });
 
     test('render component ChannelAssociatePSPPage and go back', async () => {
-        const {store, history} = renderApp();
+        renderApp();
 
         const back = screen.getByTestId('back-btn-test');
         await waitFor(() => fireEvent.click(back));
         expect(mockHistoryPush).toHaveBeenCalledWith(`ui/channels/${channelId}/psp-list`);
     });
 
-    test('fetches already associated PSPs on mount', async () => {
-        const getChannelPSPsSpy = jest.spyOn(channelService, 'getChannelPSPs');
+    test('reads associated PSP tax codes from navigation state', async () => {
+        mockLocationState = {associatedPSPTaxCodes: ['TAX001', 'TAX002']};
 
         const {store} = renderApp();
 
@@ -93,32 +97,26 @@ describe('<ChannelAssociatePSPPage />', () => {
             })
         );
 
-        await waitFor(() => {
-            expect(getChannelPSPsSpy).toHaveBeenCalledWith(channelId, '', 0, 1000);
-        });
-
-        getChannelPSPsSpy.mockRestore();
-    });
-
-    test('handles getChannelPSPs failure gracefully', async () => {
-        const getChannelPSPsSpy = jest
-            .spyOn(channelService, 'getChannelPSPs')
-            .mockRejectedValueOnce(new Error('Network error'));
-
-        const {store} = renderApp();
-
-        await waitFor(() =>
-            store.dispatch({
-                type: 'parties/setPartySelected',
-                payload: pspAdminSignedDirect,
-            })
-        );
-
-        // The page should still render without crashing
+        // Page should render without errors when state is provided
         const confirm = screen.getByTestId('confirm-btn-test');
         expect(confirm).toBeDisabled();
+    });
 
-        getChannelPSPsSpy.mockRestore();
+    test('handles missing navigation state gracefully', async () => {
+        mockLocationState = null;
+
+        const {store} = renderApp();
+
+        await waitFor(() =>
+            store.dispatch({
+                type: 'parties/setPartySelected',
+                payload: pspAdminSignedDirect,
+            })
+        );
+
+        // Page should render without crashing when no state is provided
+        const confirm = screen.getByTestId('confirm-btn-test');
+        expect(confirm).toBeDisabled();
     });
 
     test('handles associatePSPtoChannel failure with error toast', async () => {
@@ -135,7 +133,6 @@ describe('<ChannelAssociatePSPPage />', () => {
             })
         );
 
-        // Confirm button should be disabled when no PSP is selected
         const confirm = screen.getByTestId('confirm-btn-test');
         expect(confirm).toBeDisabled();
 

--- a/src/pages/channels/channelAssociatePSP/__tests__/PSPSelectionSearch.test.tsx
+++ b/src/pages/channels/channelAssociatePSP/__tests__/PSPSelectionSearch.test.tsx
@@ -72,7 +72,7 @@ describe('<PSPSelectionSearch />', () => {
     });
 
     test('render already associated PSPs as disabled', async () => {
-        const associatedTaxCodes = new Set([availablePSP[0].tax_code!]);
+        const associatedTaxCodes = [availablePSP[0].tax_code!];
 
         render(
             <Provider store={store}>
@@ -105,7 +105,7 @@ describe('<PSPSelectionSearch />', () => {
 
     test('clicking an already associated PSP does not trigger selection', async () => {
         const mockSelectionChange = jest.fn();
-        const associatedTaxCodes = new Set([availablePSP[0].tax_code!]);
+        const associatedTaxCodes = [availablePSP[0].tax_code!];
 
         render(
             <Provider store={store}>
@@ -136,7 +136,7 @@ describe('<PSPSelectionSearch />', () => {
 
     test('non-associated PSPs are rendered without disabled styles', async () => {
         // Pass an empty set so no PSP is associated
-        const associatedTaxCodes = new Set<string>();
+        const associatedTaxCodes: string[] = [];
 
         render(
             <Provider store={store}>

--- a/src/pages/channels/channelAssociatePSP/__tests__/PSPSelectionSearch.test.tsx
+++ b/src/pages/channels/channelAssociatePSP/__tests__/PSPSelectionSearch.test.tsx
@@ -19,12 +19,6 @@ afterEach(cleanup);
 
 const channelId = 'XPAY_03_ONUS';
 const availablePSP = [...mockedDelegatedPSP.delegation_list!];
-const psp = {
-    broker_psp_code: 'string',
-    description: 'string',
-    enabled: true,
-    extended_fault_bean: true,
-};
 
 const onPSPSelectionChange = jest.fn();
 
@@ -57,17 +51,6 @@ describe('<PSPSelectionSearch />', () => {
         expect(filteredPSP).toBeInTheDocument();
 
         fireEvent.click(filteredPSP);
-        // expect(onPSPSelectionChange).toHaveBeenCalledWith({
-        //     brokerId: '12345',
-        //     institutionId: '0000001',
-        //     institutionName: 'PSP1',
-        // });
-
-        // const filteredPSPContainer = screen.getByTestId('PartyItemContainer: PSP1');
-        // fireEvent.click(filteredPSPContainer);
-
-        // const clearButton = screen.getByTestId('clear-field-test');
-        // fireEvent.click(clearButton);
     });
 
     test('render component PSPSelectionSearch without available PSP and PSP selected', async () => {
@@ -86,5 +69,98 @@ describe('<PSPSelectionSearch />', () => {
                 </MemoryRouter>
             </Provider>
         );
+    });
+
+    test('render already associated PSPs as disabled', async () => {
+        const associatedTaxCodes = new Set([availablePSP[0].tax_code!]);
+
+        render(
+            <Provider store={store}>
+                <MemoryRouter initialEntries={[`/channels/${channelId}/associate-psp`]}>
+                    <Route path="/channels/:channelId/associate-psp">
+                        <ThemeProvider theme={theme}>
+                            <PSPSelectionSearch
+                                availablePSP={availablePSP}
+                                selectedPSP={undefined}
+                                associatedPSPTaxCodes={associatedTaxCodes}
+                                onPSPSelectionChange={onPSPSelectionChange}
+                            />
+                        </ThemeProvider>
+                    </Route>
+                </MemoryRouter>
+            </Provider>
+        );
+
+        const pspSelectionSearch = screen.getByTestId('psp-selection-search');
+        // Type enough to trigger filter (min 3 chars)
+        fireEvent.change(pspSelectionSearch, {target: {value: 'Azienda'}});
+
+        // The first PSP should be rendered but disabled
+        const associatedItem = screen.getByTestId(
+            `PartyItemContainer: ${availablePSP[0].institution_name}`
+        );
+        expect(associatedItem).toBeInTheDocument();
+        expect(associatedItem).toHaveStyle({opacity: '0.5', pointerEvents: 'none'});
+    });
+
+    test('clicking an already associated PSP does not trigger selection', async () => {
+        const mockSelectionChange = jest.fn();
+        const associatedTaxCodes = new Set([availablePSP[0].tax_code!]);
+
+        render(
+            <Provider store={store}>
+                <MemoryRouter initialEntries={[`/channels/${channelId}/associate-psp`]}>
+                    <Route path="/channels/:channelId/associate-psp">
+                        <ThemeProvider theme={theme}>
+                            <PSPSelectionSearch
+                                availablePSP={availablePSP}
+                                selectedPSP={undefined}
+                                associatedPSPTaxCodes={associatedTaxCodes}
+                                onPSPSelectionChange={mockSelectionChange}
+                            />
+                        </ThemeProvider>
+                    </Route>
+                </MemoryRouter>
+            </Provider>
+        );
+
+        const pspSelectionSearch = screen.getByTestId('psp-selection-search');
+        fireEvent.change(pspSelectionSearch, {target: {value: 'Azienda'}});
+
+        const associatedItem = screen.getByTestId(
+            `PartyItemContainer: ${availablePSP[0].institution_name}`
+        );
+        fireEvent.click(associatedItem);
+        expect(mockSelectionChange).not.toHaveBeenCalled();
+    });
+
+    test('non-associated PSPs are rendered without disabled styles', async () => {
+        // Pass an empty set so no PSP is associated
+        const associatedTaxCodes = new Set<string>();
+
+        render(
+            <Provider store={store}>
+                <MemoryRouter initialEntries={[`/channels/${channelId}/associate-psp`]}>
+                    <Route path="/channels/:channelId/associate-psp">
+                        <ThemeProvider theme={theme}>
+                            <PSPSelectionSearch
+                                availablePSP={availablePSP}
+                                selectedPSP={undefined}
+                                associatedPSPTaxCodes={associatedTaxCodes}
+                                onPSPSelectionChange={onPSPSelectionChange}
+                            />
+                        </ThemeProvider>
+                    </Route>
+                </MemoryRouter>
+            </Provider>
+        );
+
+        const pspSelectionSearch = screen.getByTestId('psp-selection-search');
+        fireEvent.change(pspSelectionSearch, {target: {value: 'Azienda'}});
+
+        const pspItem = screen.getByTestId(
+            `PartyItemContainer: ${availablePSP[0].institution_name}`
+        );
+        expect(pspItem).not.toHaveStyle({opacity: '0.5', pointerEvents: 'none'});
     });
 });

--- a/src/pages/channels/channelAssociatePSP/__tests__/PSPSelectionSearchItemContainer.test.tsx
+++ b/src/pages/channels/channelAssociatePSP/__tests__/PSPSelectionSearchItemContainer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import PSPSelectionSearchItemContainer from '../PSPSelectionSearchItemContainer';
 
 describe('<PSPSelectionSearchItemContainer />', () => {
@@ -7,5 +7,81 @@ describe('<PSPSelectionSearchItemContainer />', () => {
         render(
             <PSPSelectionSearchItemContainer title={undefined} subTitle={undefined} image={undefined}/>
         );
+    });
+
+    test('render component PSPSelectionSearchItemContainer with disabled prop', () => {
+        render(
+            <PSPSelectionSearchItemContainer
+                title={'PSP Test'}
+                subTitle={'Già associato'}
+                image={undefined}
+                disabled={true}
+            />
+        );
+        const container = screen.getByTestId('PartyItemContainer: PSP Test');
+        expect(container).toBeInTheDocument();
+        expect(container).toHaveStyle({opacity: '0.5', pointerEvents: 'none'});
+    });
+
+    test('render component PSPSelectionSearchItemContainer enabled does not have disabled styles', () => {
+        const mockAction = jest.fn();
+        render(
+            <PSPSelectionSearchItemContainer
+                title={'PSP Enabled'}
+                subTitle={''}
+                image={undefined}
+                disabled={false}
+                action={mockAction}
+            />
+        );
+        const container = screen.getByTestId('PartyItemContainer: PSP Enabled');
+        expect(container).toBeInTheDocument();
+        expect(container).not.toHaveStyle({opacity: '0.5'});
+    });
+
+    test('disabled PSPSelectionSearchItemContainer does not trigger action on keydown', () => {
+        const mockAction = jest.fn();
+        render(
+            <PSPSelectionSearchItemContainer
+                title={'PSP Disabled'}
+                subTitle={'Già associato'}
+                image={undefined}
+                disabled={true}
+                action={mockAction}
+            />
+        );
+        const container = screen.getByTestId('PartyItemContainer: PSP Disabled');
+        fireEvent.keyDown(container, {key: 'Enter'});
+        expect(mockAction).not.toHaveBeenCalled();
+    });
+
+    test('enabled PSPSelectionSearchItemContainer triggers action on keydown Enter', () => {
+        const mockAction = jest.fn();
+        render(
+            <PSPSelectionSearchItemContainer
+                title={'PSP Active'}
+                subTitle={''}
+                image={undefined}
+                disabled={false}
+                action={mockAction}
+            />
+        );
+        const container = screen.getByTestId('PartyItemContainer: PSP Active');
+        fireEvent.keyDown(container, {key: 'Enter'});
+        expect(mockAction).toHaveBeenCalled();
+    });
+
+    test('default disabled is false when not provided', () => {
+        const mockAction = jest.fn();
+        render(
+            <PSPSelectionSearchItemContainer
+                title={'PSP Default'}
+                subTitle={''}
+                image={undefined}
+                action={mockAction}
+            />
+        );
+        const container = screen.getByTestId('PartyItemContainer: PSP Default');
+        expect(container).not.toHaveStyle({opacity: '0.5', pointerEvents: 'none'});
     });
 });

--- a/src/pages/channels/channelPSPList/ChannelPSPListPage.tsx
+++ b/src/pages/channels/channelPSPList/ChannelPSPListPage.tsx
@@ -20,6 +20,7 @@ const ChannelPSPListPage = () => {
 
     const [pspNameInput, setPspNameInput] = useState<string>('');
     const [pspNameFilter, setPspNameFilter] = useState<string>('');
+    const [associatedPSPTaxCodes, setAssociatedPSPTaxCodes] = useState<Array<string>>([]);
 
     useEffect(() => {
         const setSearchValue = setTimeout(() => {
@@ -104,9 +105,10 @@ const ChannelPSPListPage = () => {
                 channelId={channelId}
                 pspNameInput={pspNameInput}
                 setPspNameInput={setPspNameInput}
+                associatedPSPTaxCodes={associatedPSPTaxCodes}
             />
 
-            <ChannelPSPTable pspNameFilter={pspNameFilter} setAlertMessage={setAlertMessage}/>
+            <ChannelPSPTable pspNameFilter={pspNameFilter} setAlertMessage={setAlertMessage} onAssociatedPSPTaxCodesChange={setAssociatedPSPTaxCodes}/>
         </SideMenuLayout>
     );
 };

--- a/src/pages/channels/channelPSPList/ChannelPSPTable.tsx
+++ b/src/pages/channels/channelPSPList/ChannelPSPTable.tsx
@@ -77,13 +77,16 @@ export default function ChannelPSPTable({setAlertMessage, pspNameFilter, onAssoc
                 ? pspListPage.page_info?.total_pages * pspListPage.page_info?.items_found
                 : prevRowCountState
         );
+    }, [pspListPage.page_info?.total_pages, setRowCountState]);
+
+    useEffect(() => {
         if (onAssociatedPSPTaxCodesChange) {
             const taxCodes = (pspListPage.payment_service_providers ?? [])
                 .map((psp) => psp.tax_code)
                 .filter((tc): tc is string => !!tc);
             onAssociatedPSPTaxCodesChange(taxCodes);
         }
-    }, [pspListPage.page_info?.total_pages, setRowCountState]);
+    }, [pspListPage.payment_service_providers]);
 
     const dissociatePSP = async () => {
         setShowConfirmModal(false);

--- a/src/pages/channels/channelPSPList/ChannelPSPTable.tsx
+++ b/src/pages/channels/channelPSPList/ChannelPSPTable.tsx
@@ -28,9 +28,10 @@ const emptyPSPList: ChannelPspListResource = {
 type ChannelPSPTableProps = {
     setAlertMessage: any;
     pspNameFilter: string;
+    onAssociatedPSPTaxCodesChange?: (taxCodes: Array<string>) => void;
 };
 
-export default function ChannelPSPTable({setAlertMessage, pspNameFilter}: ChannelPSPTableProps) {
+export default function ChannelPSPTable({setAlertMessage, pspNameFilter, onAssociatedPSPTaxCodesChange}: ChannelPSPTableProps) {
     const {t} = useTranslation();
     const [showConfirmModal, setShowConfirmModal] = useState(false);
     const [error, setError] = useState(false);
@@ -76,6 +77,12 @@ export default function ChannelPSPTable({setAlertMessage, pspNameFilter}: Channe
                 ? pspListPage.page_info?.total_pages * pspListPage.page_info?.items_found
                 : prevRowCountState
         );
+        if (onAssociatedPSPTaxCodesChange) {
+            const taxCodes = (pspListPage.payment_service_providers ?? [])
+                .map((psp) => psp.tax_code)
+                .filter((tc): tc is string => !!tc);
+            onAssociatedPSPTaxCodesChange(taxCodes);
+        }
     }, [pspListPage.page_info?.total_pages, setRowCountState]);
 
     const dissociatePSP = async () => {

--- a/src/pages/channels/channelPSPList/ChannelPSPTableSearchBar.tsx
+++ b/src/pages/channels/channelPSPList/ChannelPSPTableSearchBar.tsx
@@ -9,9 +9,10 @@ type Props = {
     channelId: string;
     pspNameInput: string;
     setPspNameInput: (pspName: string) => void;
+    associatedPSPTaxCodes?: Array<string>;
 };
 
-export default function ChannelPSPTableSearchBar({channelId, pspNameInput, setPspNameInput}: Props) {
+export default function ChannelPSPTableSearchBar({channelId, pspNameInput, setPspNameInput, associatedPSPTaxCodes = []}: Props) {
     const {t} = useTranslation();
     return (
         <Box width="100%" display="flex">
@@ -32,9 +33,12 @@ export default function ChannelPSPTableSearchBar({channelId, pspNameInput, setPs
             />
             <Button
                 component={Link}
-                to={generatePath(ROUTES.CHANNEL_ASSOCIATE_PSP, {
-                    channelId,
-                })}
+                to={{
+                    pathname: generatePath(ROUTES.CHANNEL_ASSOCIATE_PSP, {
+                        channelId,
+                    }),
+                    state: {associatedPSPTaxCodes},
+                }}
                 variant="contained"
                 sx={{ml: 1, whiteSpace: 'nowrap', minWidth: 'auto'}}
                 startIcon={<Add/>}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Removed wrong API call `getBrokerAndPspDetails`
- Fixed infinite loop loading
- Add check to disable already associated PSP

#### Motivation and Context

This change was required due to a problem blocking association of new PSP.

#### How Has This Been Tested?

- DEV test with PSP DEMO DIRECT

#### Screenshots (if appropriate):

BEFORE (error 403 and infinite loading):
<img width="1919" height="922" alt="image" src="https://github.com/user-attachments/assets/c8bb97e5-49fe-4843-8b75-5453458a8160" />

AFTER (association completed with 200 for PSP Signed Direct):
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/d36091d6-7d6d-4535-9bd2-89f215b50d4b" />

Check already associated PSP:
<img width="1919" height="913" alt="image" src="https://github.com/user-attachments/assets/e359c0eb-5d05-4a3f-bc93-100de5bfe194" />

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
